### PR TITLE
README typo & -D flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ ICLR 2020, https://arxiv.org/abs/1909.05215
 
 Until the cryoDRGN conda package is available, for now, git clone the source code and install the following dependencies with anaconda, replacing the cudatoolkit version as necessary:
 
-    conda create --name cryodrgn python=3.7
+    conda create --name cryodrgn --python 3.7
     conda activate cryodrgn
-    conda install pytorch torchvision cudatoolkit=10.1 -c pytorch
-    conda install pandas
+    conda install pytorch=1.0.1 torchvision cudatoolkit=10.0 -c pytorch
 
 Additional requirements for latent space analysis and interactive visualization:
 
@@ -51,7 +50,9 @@ To parse image poses from a RELION starfile:
 
 To parse image poses from a cryoSPARC homogeneous refinement particles.cs file:
 
-    $ python $CDRGN_SRC/utils/parse_pose_csparc.py cryosparc_P27_J3_005_particles.cs -o pose.pkl
+    $ python $CDRGN_SRC/utils/parse_pose_csparc.py cryosparc_P27_J3_005_particles.cs -o pose.pkl -D 300
+
+The `-D` argument should be set to the box size of the original reconstruction (before any downsampling). 
 
 ### 3. Parse CTF parameters from a .star/.cs file
 
@@ -62,7 +63,7 @@ Example usage:
     # .star file
     $ python $CDRGN_SRC/utils/parse_ctf_star.py particles.star -D 300 --Apix 1.03 -o ctf.pkl
     # .cs file
-    $ python $CDRGN_SRC/utils/parse_ctf_star.py cryosparc_P27_J3_005_particles.cs -o ctf.pkl
+    $ python $CDRGN_SRC/utils/parse_ctf_csparc.py cryosparc_P27_J3_005_particles.cs -o ctf.pkl
 
 The `-D` and `--Apix` arguments should be set to the box size and Angstrom/pixel of the original `.mrcs` file (before any downsampling). 
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ ICLR 2020, https://arxiv.org/abs/1909.05215
 
 Until the cryoDRGN conda package is available, for now, git clone the source code and install the following dependencies with anaconda, replacing the cudatoolkit version as necessary:
 
-    conda create --name cryodrgn --python 3.7
+    conda create --name cryodrgn python=3.7
     conda activate cryodrgn
-    conda install pytorch=1.0.1 torchvision cudatoolkit=10.0 -c pytorch
+    conda install pytorch torchvision cudatoolkit=10.1 -c pytorch
+    conda install pandas
 
 Additional requirements for latent space analysis and interactive visualization:
 

--- a/utils/analysis/cryoDRGN_viz_template.ipynb
+++ b/utils/analysis/cryoDRGN_viz_template.ipynb
@@ -446,7 +446,7 @@
    "source": [
     "# View PCA\n",
     "plt.scatter(pc[:,0], pc[:,1], alpha=.1, s=1)\n",
-    "plt.scatter(pc[selected_ind,0], pc[selected_ind,1], alpha=.1, s=1)\n",
+    "plt.scatter(pc[ind_selected,0], pc[ind_selected,1], alpha=.1, s=1)\n",
     "plt.xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
     "plt.ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))"
    ]
@@ -459,7 +459,7 @@
    "source": [
     "# View umap\n",
     "plt.scatter(umap[:,0], umap[:,1], alpha=.1, s=1)\n",
-    "plt.scatter(umap[selected_ind,0], umap[selected_ind,1], alpha=.1, s=1)\n",
+    "plt.scatter(umap[ind_selected,0], umap[ind_selected,1], alpha=.1, s=1)\n",
     "plt.xlabel('UMAP1')\n",
     "plt.ylabel('UMAP2')"
    ]


### PR DESCRIPTION
fix typo: ctf_star to ctf_csparc
req'd -D flag doc missing for parse_pose_csparc

Please verify I correctly interpreted -D