### PR TITLE
Suppress warnings from seaborn in Jupyter notebooks

### DIFF
--- a/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
@@ -296,7 +296,8 @@
    "outputs": [],
    "source": [
     "# translations\n",
-    "sns.jointplot(trans[:,0],trans[:,1],\n",
+    "sns.jointplot(x=trans[:,0],\n",
+    "              y=trans[:,1],\n",
     "              kind='hex').set_axis_labels('tx (fraction)','ty (fraction)')"
    ]
   },
@@ -341,7 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(pc[:,0], pc[:,1], alpha=.1, s=1)\n",
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], alpha=.1, s=1)\n",
     "g.set_axis_labels('PC1', 'PC2')"
    ]
   },
@@ -351,7 +352,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(pc[:,0], pc[:,1], kind='hex')\n",
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], kind='hex')\n",
     "g.set_axis_labels('PC1', 'PC2')"
    ]
   },
@@ -380,7 +381,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(umap[:,0], umap[:,1], alpha=.1, s=1)\n",
+    "g = sns.jointplot(x=umap[:,0], y=umap[:,1], alpha=.1, s=1)\n",
     "g.set_axis_labels('UMAP1', 'UMAP2')"
    ]
   },
@@ -390,7 +391,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(umap[:,0], umap[:,1], kind='hex')\n",
+    "g = sns.jointplot(x=umap[:,0], y=umap[:,1], kind='hex')\n",
     "g.set_axis_labels('UMAP1', 'UMAP2')"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_viz_template.ipynb
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(pc[:,0], pc[:,1], alpha=.1, s=1)\n",
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], alpha=.1, s=1)\n",
     "g.set_axis_labels('PC1', 'PC2')"
    ]
   },
@@ -271,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(pc[:,0], pc[:,1], kind='hex')\n",
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], kind='hex')\n",
     "g.set_axis_labels('PC1', 'PC2')"
    ]
   },
@@ -311,7 +311,8 @@
    "outputs": [],
    "source": [
     "# translations\n",
-    "sns.jointplot(trans[:,0],trans[:,1],\n",
+    "sns.jointplot(x=trans[:,0],\n",
+    "              y=trans[:,1],\n",
     "              kind='hex').set_axis_labels('tx (fraction)','ty (fraction)')"
    ]
   },
@@ -328,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(umap[:,0], umap[:,1], alpha=.1, s=1)\n",
+    "g = sns.jointplot(x=umap[:,0], y=umap[:,1], alpha=.1, s=1)\n",
     "g.set_axis_labels('UMAP1', 'UMAP2')"
    ]
   },
@@ -338,7 +339,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(umap[:,0], umap[:,1], kind='hex')\n",
+    "g = sns.jointplot(x=umap[:,0], y=umap[:,1], kind='hex')\n",
     "g.set_axis_labels('UMAP1', 'UMAP2')"
    ]
   },


### PR DESCRIPTION
From version 0.12, seaborn will require named arguments for X and Y axes of a plot.

This commit adds a minor modification to Jupyter notebooks in `cryodrgn/templates/` to suppress this warning from seaborn:

```
/opt/miniconda3/envs/cryodrgn-latest/lib/python3.7/site-packages/seaborn/_decorators.py:43: FutureWarning:

Pass the following variables as keyword args: x, y. From version 0.12, the only valid positional argument
will be `data`, and passing other arguments without an explicit keyword will result in an error or
misinterpretation.
```