### PR TITLE
Support mode 12 (float16) MRC files from RELION 4.0

### DIFF
--- a/cryodrgn/mrc.py
+++ b/cryodrgn/mrc.py
@@ -14,6 +14,7 @@ DTYPE_FOR_MODE = {0:np.int8,
                   3:'2h', # complex number from 2 shorts
                   4:np.complex64,
                   6:np.uint16,
+                  12:np.float16,
                   16:'3B'} # RBG values
 MODE_FOR_DTYPE = {vv:kk for kk,vv in DTYPE_FOR_MODE.items()}
 
@@ -43,6 +44,7 @@ class MRCHeader:
         self.fields = OrderedDict(zip(self.FIELDS,header_values))
         self.extended_header = extended_header
         self.D = self.fields['nx']
+        self.dtype = DTYPE_FOR_MODE[self.fields['mode']]
 
     def __str__(self):
         return f'Header: {self.fields}\nExtended header: {self.extended_header}'
@@ -146,7 +148,7 @@ def parse_mrc(fname, lazy=False):
     extbytes = header.fields['next']
     start = 1024+extbytes # start of image data
 
-    dtype = DTYPE_FOR_MODE[header.fields['mode']]
+    dtype = header.dtype
     nz, ny, nx = header.fields['nz'], header.fields['ny'], header.fields['nx']
     
     # load all in one block

--- a/cryodrgn/starfile.py
+++ b/cryodrgn/starfile.py
@@ -90,9 +90,10 @@ class Starfile():
             mrcs = prefix_paths(mrcs, datadir)
         for path in set(mrcs):
             assert os.path.exists(path), f'{path} not found'
-        D = mrc.parse_header(mrcs[0]).D # image size along one dimension in pixels
-        dtype = np.float32
-        stride = np.float32().itemsize*D*D
+        header = mrc.parse_header(mrcs[0])
+        D = header.D # image size along one dimension in pixels
+        dtype = header.dtype
+        stride = dtype().itemsize*D*D
         dataset = [LazyImage(f, (D,D), dtype, 1024+ii*stride) for ii,f in zip(ind, mrcs)]
         if not lazy:
             dataset = np.array([x.get() for x in dataset])


### PR DESCRIPTION
The upcoming RELION 4.0 will introduce [MRC mode 12](https://www.ccpem.ac.uk/mrc_format/mrc_proposals.php) (half precision float, i.e., float16) to save disk space.

Sample image are ftp://ftp.mrc-lmb.cam.ac.uk/pub/tnakane/20170629_00024_frameImage_float16.mrc (whole micrograph) and ftp://ftp.mrc-lmb.cam.ac.uk/pub/tnakane/20170629_00024_frameImage_float16.mrc (one particle).

The following patch adds float16 support for RELION STAR files. 

I tested this as:
```
python -m cryodrgn downsample -D 128 -o cryodrgn/stack.mrcs --relion31 Refine3D/float16/run_data.star
python -m cryodrgn parse_pose_star Refine3D/float16/run_data.star -o cryodrgn/pose.pkl -D 200 --relion31 --Apix 1.416
python -m cryodrgn parse_ctf_star Refine3D/float16/run_data.star -o cryodrgn/ctf.pkl -D 200 --relion31 -w 0.1 --kv 200 --cs 1.4 --Apix 1.416
python -m cryodrgn backproject_voxel cryodrgn/stack.mrcs --poses cryodrgn/pose.pkl --ctf cryodrgn/ctf.pkl -o cryodrgn/backproject.mrc
```

Other sub-commands should work as well, because they operate on float32 particles written by CryoDRGN itself.

My current patch assumes all particles in a STAR file are float32 or float16 but not mixtures. To properly support more complicated cases, further refactoring is necessary. I also recommend using the `mrcfile` package instead of having your own MRC library.