### PR TITLE
filter_star.py handling relion 3.1 star files

### DIFF
--- a/cryodrgn/starfile.py
+++ b/cryodrgn/starfile.py
@@ -12,57 +12,87 @@ from .mrc import LazyImage
 
 class Starfile():
     
-    def __init__(self, headers, df):
+    def __init__(self, headers, df, headers_optics=None, df_optics=None):
         assert headers == list(df.columns), f'{headers} != {df.columns}'
         self.headers = headers
         self.df = df
+        if headers_optics is not None: # file is recognized as a RELION 3.1 star file
+            self.headers_optics = headers_optics
+            self.df_optics = df_optics
 
     @classmethod
     def load(self, starfile, relion31=False):
-        f = open(starfile,'r')
-        # get to data block
-        BLOCK = 'data_particles' if relion31 else 'data_'
-        while 1:
-            for line in f:
-                if line.startswith(BLOCK):
-                    break
-            break
-        # get to header loop
-        while 1:
-            for line in f:
-                if line.startswith('loop_'):
-                    break
-            break
-        # get list of column headers
-        while 1:
-            headers = []
-            for line in f:
-                if line.startswith('_'):
-                    headers.append(line)
-                else:
-                    break
-            break 
-        # assume all subsequent lines until empty line is the body
-        headers = [h.strip().split()[0] for h in headers]
-        body = [line]
-        for line in f:
-            if line.strip() == '':
+        def parse_starblock_to_df(filehandle, BLOCK):
+            # get to block
+            while 1:
+                for line in f:
+                    if line.startswith(BLOCK):
+                        assert line.strip().split()[0] == BLOCK, f"Expected block header: {BLOCK} but found: {line.strip().split()[0]}. Is this a RELION 3.1 starfile?"
+                        break
                 break
-            body.append(line)
-        # put data into an array and instantiate as dataframe
-        words = [l.strip().split() for l in body]
-        words = np.array(words)
-        assert words.ndim == 2, f"Uneven # columns detected in parsing {set([len(x) for x in words])}. Is this a RELION 3.1 starfile?" 
-        assert words.shape[1] == len(headers), f"Error in parsing. Number of columns {words.shape[1]} != number of headers {len(headers)}" 
-        data = {h:words[:,i] for i,h in enumerate(headers)}
-        df = pd.DataFrame(data=data)
-        return self(headers, df)
+            # get to header loop
+            while 1:
+                for line in f:
+                    if line.startswith('loop_'):
+                        break
+                break
+            # get list of column headers
+            while 1:
+                headers = []
+                for line in f:
+                    if line.startswith('_'):
+                        headers.append(line)
+                    else:
+                        break
+                break
+            # assume all subsequent lines until empty line is the body
+            headers = [h.strip().split()[0] for h in headers]
+            assert headers != [], "Could not find headers in file. Please double check if this is a RELION 3.1 starfile."
+            if line.strip() != '':
+                body = [line]
+            else:
+                body = []
+            for line in f:
+                if line.strip() == '':
+                    break
+                body.append(line)
+            # put data into an array and instantiate as dataframe
+            words = [l.strip().split() for l in body]
+            words = np.array(words)
+            assert words.shape[1] == len(headers), f"Error in parsing. Number of columns {words.shape[1]} != number of headers {len(headers)}"
+            data = {h: words[:, i] for i, h in enumerate(headers)}
+            df = pd.DataFrame(data=data)
+            return headers, df
 
-    def write(self, outstar):
+        f = open(starfile,'r')
+
+        # parse data_optics block if relion3.1 starfile
+        if relion31:
+            BLOCK = 'data_optics'
+            headers_optics, df_optics = parse_starblock_to_df(f, BLOCK)
+
+        # parse data block
+        BLOCK = 'data_particles' if relion31 else 'data_'
+        headers, df = parse_starblock_to_df(f, BLOCK)
+
+        if relion31:
+            return self(headers, df, headers_optics, df_optics)
+        else:
+            return self(headers, df)
+
+    def write(self, outstar, relion31=False):
         f = open(outstar,'w')
         f.write('# Created {}\n'.format(dt.now()))
         f.write('\n')
-        f.write('data_\n\n')
+        if relion31:
+            f.write('data_optics\n\n')
+            f.write('loop_\n')
+            f.write('\n'.join(self.headers_optics))
+            f.write('\n')
+            for i in self.df_optics.index:
+                f.write(' '.join([str(v) for v in self.df_optics.loc[i]]))
+                f.write('\n\n')
+        f.write('data_particles\n\n') if relion31 else f.write('data_\n\n')
         f.write('loop_\n')
         f.write('\n'.join(self.headers))
         f.write('\n')

--- a/utils/filter_star.py
+++ b/utils/filter_star.py
@@ -1,7 +1,6 @@
 '''
 Filter a .star file
 
-(Note: RELION 3.1 star files are not supported)
 '''
 
 import argparse
@@ -18,16 +17,17 @@ def parse_args():
     parser.add_argument('input', help='Input .star file')
     parser.add_argument('--ind', required=True, help='Selected indices array (.pkl)')
     parser.add_argument('-o', help='Output .star file')
+    parser.add_argument('--relion31', action='store_true', help='Flag if relion3.1 star format')
     return parser
 
 def main(args):
-    s = starfile.Starfile.load(args.input, relion31=False)
+    s = starfile.Starfile.load(args.input, relion31=args.relion31)
     ind = utils.load_pkl(args.ind)
     log('{} particles'.format(len(s.df)))
     s.df = s.df.loc[ind]
     log(len(s.df))
     log(len(s.df.index))
-    s.write(args.o)
+    s.write(args.o, relion31=args.relion31)
 
 if __name__ == '__main__':
     main(parse_args().parse_args())


### PR DESCRIPTION
This pull request was motivated by wanting to examine particles filtered by cryoDRGN via traditional reconstruction tools, particularly RELION 3.1. This required maintaining the data_optics block in a RELION 3.1 star file after filtering particle indices.

Modified starfile.py:
- Added Starfile.df_optics and Starfile.headers_optics attributes when loading a RELION 3.1 star file with relion31=True
- Slightly refactored Starfile.load() file parsing to minimize new and otherwise redundant code
- Updated Starfile.load() assertions based on refactoring to detect if relion31=True should or should not be set by user
- Starfile.write() now writes data_optics block in addition to data_particles if relion31=True (default False)

Modified filter_star.py:
- Is now compatible to filter and write out RELION 3.1 star files including data_optics block if --relion31 is set
- Successfully tested filtering on RELION 3.0 and RELION 3.1 star files