### PR TITLE
Fix syntax error

### DIFF
--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -315,7 +315,7 @@ def main(args):
             assert args.preprocessed, "Dataset must be preprocesed with `cryodrgn preprocess_mrcs` in order to use --lazy data loading"
             assert not args.ind, "For --lazy data loading, dataset must be filtered by `cryodrgn preprocess_mrcs`"
             #data = dataset.PreprocessedMRCData(args.particles, norm=args.norm)
-            raise NotImplementedError, "Use --lazy-single for on-the-fly image loading"
+            raise NotImplementedError("Use --lazy-single for on-the-fly image loading")
         elif args.lazy_single:
             data = dataset.LazyMRCData(args.particles, norm=args.norm, invert_data=args.invert_data, ind=ind, keepreal=args.use_real, window=args.window, datadir=args.datadir, relion31=args.relion31, window_r=args.window_r)
         elif args.preprocessed:


### PR DESCRIPTION
The below line in the previous commit ab2a3623a863fe5ee413a3ce94085f0e090ee982 causes a syntax error in my environment.
https://github.com/zhonge/cryodrgn/blob/ab2a3623a863fe5ee413a3ce94085f0e090ee982/cryodrgn/commands/train_vae.py#L318

This pull request fixes the syntax error.