### PR TITLE
Add the shebang syntax to quicktest.sh

### DIFF
--- a/testing/quicktest.sh
+++ b/testing/quicktest.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 set -e
 set -x
 cryodrgn train_vae  data/hand.mrcs -o output/toy_recon_vae --lr .0001 --seed 0 --poses data/hand_rot.pkl --zdim 10 


### PR DESCRIPTION
quicktest.sh is a shell executable, but currently it fails to execute because it is just missing the shebang to invoke sh.