### PR TITLE
parse_loss crashes when epoch took longer than a day

### DIFF
--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -1,4 +1,5 @@
 import os
+import re
 import numpy as np
 import pickle
 import matplotlib.pyplot as plt
@@ -19,12 +20,10 @@ def parse_loss(f):
     '''Parse loss from run.log'''
     lines = open(f).readlines()
     lines = [x for x in lines if '====' in x]
-    try:
-        loss = [x.strip().split()[-1] for x in lines]
-        loss = np.asarray(loss).astype(np.float32)
-    except:
-        loss = [x.split()[-4][:-1] for x in lines]
-        loss = np.asarray(loss).astype(np.float32)
+    regex = "total\sloss\s=\s(\d.\d+)"
+    loss = [re.search(regex, x).group(1) for x in lines]
+    loss = np.asarray(loss).astype(np.float32)
+
     return loss
 
 ### Dimensionality reduction ###


### PR DESCRIPTION
Hi,

we have a case where an epoch took longer than a day. In this case, the log looks like this:

```
2021-12-15 21:19:48     # =====> Epoch: 1 Average gen loss = 0.642962, KLD = 8.001944, total loss = 0.642977; Finished in 10:38:45.354113
2021-12-16 09:47:25     # =====> Epoch: 2 Average gen loss = 0.642043, KLD = 12.747103, total loss = 0.642066; Finished in 11:41:42.980521
2021-12-17 22:14:08     # =====> Epoch: 3 Average gen loss = 0.641815, KLD = 15.868928, total loss = 0.641843; Finished in 1 day, 4:55:28.841974
2021-12-19 02:29:25     # =====> Epoch: 4 Average gen loss = 0.641687, KLD = 16.430466, total loss = 0.641716; Finished in 1 day, 0:23:14.855539
2021-12-19 09:53:20     # =====> Epoch: 5 Average gen loss = 0.641612, KLD = 16.839718, total loss = 0.641641; Finished in 6:41:22.381529
```

parse_loss crashes in those cases.

I replaced it with a regular expression which is more stable:
https://regex101.com/r/dLjg9t/1

Best,
Thorsten
