### PR TITLE
rename enc-xx to pe-xx to avoid ambiguity

### DIFF
--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -375,7 +375,7 @@ def main(args):
     activation={"relu": nn.ReLU, "leaky_relu": nn.LeakyReLU}[args.activation]
     model = HetOnlyVAE(lattice, args.qlayers, args.qdim, args.players, args.pdim,
                 in_dim, args.zdim, encode_mode=args.encode_mode, enc_mask=enc_mask,
-                enc_type=args.pe_type, enc_dim=args.pe_dim, domain=args.domain,
+                pe_type=args.pe_type, pe_dim=args.pe_dim, domain=args.domain,
                 activation=activation, feat_sigma=args.feat_sigma)
     model.to(device)
     flog(model)


### PR DESCRIPTION
In `models.py`, the type/dim of the positonal encoding is refered as `enc_dim`, which is confusing since `enc_dim` already denotes the dimenionality of the encoder. I renamed them to keep in consistency with `train_vae.py`.