### PR TITLE
pin ipywidgets version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(name='cryodrgn',
         'cufflinks',
         'jupyterlab',
         'umap-learn',
-        'ipywidgets'
+        'ipywidgets<8'
         ]
      )


### PR DESCRIPTION
Pinning ipywidgets to < 8 till the following issue is fixed https://github.com/plotly/plotly.py/issues/3686. Fixes issue #137 