### PR TITLE
add --lazy option to reduce the memory usage and add --use_cupy option to speed up preprocess

### DIFF
--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -52,6 +52,7 @@ def add_args(parser):
     group.add_argument('--datadir', type=os.path.abspath, help='Path prefix to particle stack if loading relative paths from a .star or .cs file')
     group.add_argument('--lazy', action='store_true', help='Lazy loading if full dataset is too large to fit in memory (Should copy dataset to SSD)')
     group.add_argument('--preprocessed', action='store_true', help='Skip preprocessing steps if input data is from cryodrgn preprocess_mrcs')
+    group.add_argument('--num-workers-per-gpu', type=int, default=4, help='Number of num_workers of Dataloader (default: %(default)s)')
     group.add_argument('--max-threads', type=int, default=16, help='Maximum number of CPU cores for FFT parallelization (default: %(default)s)')
 
     group = parser.add_argument_group('Tilt series')
@@ -124,7 +125,8 @@ def preprocess_input(y, yt, lattice, trans):
     B = y.size(0)
     D = lattice.D
     y = lattice.translate_ht(y.view(B,-1), trans.unsqueeze(1)).view(B,D,D)
-    if yt is not None: yt = lattice.translate_ht(yt.view(B,-1), trans.unsqueeze(1)).view(B,D,D)
+    if yt is not None: 
+        yt = lattice.translate_ht(yt.view(B,-1), trans.unsqueeze(1)).view(B,D,D)
     return y, yt
 
 def _unparallelize(model):
@@ -319,13 +321,13 @@ def main(args):
     flog(f'Loading dataset from {args.particles}')
     if args.tilt is None:
         tilt = None
-        args.use_real = args.encode_mode == 'conv'
+        args.use_real = (args.encode_mode == 'conv') # Must be False
 
-        if args.lazy:
+        if args.lazy and not args.preprocessed:
             data = dataset.LazyMRCData(args.particles, norm=args.norm, invert_data=args.invert_data, ind=ind, keepreal=args.use_real, window=args.window, datadir=args.datadir, window_r=args.window_r, flog=flog)
         elif args.preprocessed:
             flog(f'Using preprocessed inputs. Ignoring any --window/--invert-data options')
-            data = dataset.PreprocessedMRCData(args.particles, norm=args.norm, ind=ind, flog=flog)
+            data = dataset.PreprocessedMRCData(args.particles, norm=args.norm, ind=ind, flog=flog, lazy=args.lazy)
         else:
             data = dataset.MRCData(args.particles, norm=args.norm, invert_data=args.invert_data, ind=ind, keepreal=args.use_real, window=args.window, datadir=args.datadir, max_threads=args.max_threads, window_r=args.window_r, flog=flog)
 
@@ -356,7 +358,7 @@ def main(args):
         ctf_params = ctf.load_ctf_for_training(D-1, args.ctf)
         if args.ind is not None: ctf_params = ctf_params[ind]
         assert ctf_params.shape == (Nimg, 8)
-        ctf_params = torch.tensor(ctf_params, device=device)
+        ctf_params = torch.tensor(ctf_params, device=device) # Nx8
     else: ctf_params = None
 
     # instantiate model
@@ -418,16 +420,19 @@ def main(args):
         start_epoch = 0
 
     # parallelize
+    num_workers_per_gpu = args.num_workers_per_gpu
     if args.multigpu and torch.cuda.device_count() > 1:
         log(f'Using {torch.cuda.device_count()} GPUs!')
         args.batch_size *= torch.cuda.device_count()
+        if num_workers_per_gpu * torch.cuda.device_count() > os.cpu_count():
+            num_workers_per_gpu = max(1, os.cpu_count()//torch.cuda.device_count() )
         log(f'Increasing batch size to {args.batch_size}')
         model = nn.DataParallel(model)
     elif args.multigpu:
         log(f'WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected')
 
     # training loop
-    data_generator = DataLoader(data, batch_size=args.batch_size, shuffle=True)
+    data_generator = DataLoader(data, batch_size=args.batch_size, shuffle=True, num_workers=num_workers_per_gpu)
     num_epochs = args.num_epochs
     for epoch in range(start_epoch, num_epochs):
         t2 = dt.now()
@@ -436,7 +441,7 @@ def main(args):
         kld_accum = 0
         eq_loss_accum = 0
         batch_it = 0 
-        for minibatch in data_generator:
+        for minibatch in data_generator: # minibatch: [y, ind]
             ind = minibatch[-1].to(device)
             y = minibatch[0].to(device)
             yt = minibatch[1].to(device) if tilt is not None else None

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -1,9 +1,15 @@
 import numpy as np
+try:
+    import cupy as cp
+except:
+    cp = None
+
 import torch
 from torch.utils import data
 import os
 import multiprocessing as mp
 from multiprocessing import Pool
+from tqdm.auto import tqdm
 
 from . import fft
 from . import mrc
@@ -41,7 +47,7 @@ class LazyMRCData(data.Dataset):
     '''
     Class representing an .mrcs stack file -- images loaded on the fly
     '''
-    def __init__(self, mrcfile, norm=None, keepreal=False, invert_data=False, ind=None, window=True, datadir=None, window_r=0.85, flog=None):
+    def __init__(self, mrcfile, norm=None, keepreal=False, invert_data=False, ind=None, window=True, datadir=None, window_r=0.85, flog=None, use_cupy=False):
         log = flog if flog is not None else utils.log
         assert not keepreal, 'Not implemented error'
         particles = load_particles(mrcfile, True, datadir=datadir)
@@ -52,7 +58,7 @@ class LazyMRCData(data.Dataset):
         assert ny == nx, "Images must be square"
         assert ny % 2 == 0, "Image size must be even. Is this a preprocessed dataset? Use the --preprocessed flag if so."
         log('Loaded {} {}x{} images'.format(N, ny, nx))
-        self.particles = particles.astype(np.float32)
+        self.particles = particles
         self.N = N
         self.D = ny + 1 # after symmetrizing HT
         self.invert_data = invert_data
@@ -60,22 +66,27 @@ class LazyMRCData(data.Dataset):
             norm = self.estimate_normalization()
         self.norm = norm
         self.window = window_mask(ny, window_r, .99) if window else None
+        self.use_cupy = use_cupy
 
     def estimate_normalization(self, n=1000):
+        pp = cp if (self.use_cupy and cp is not None) else np
+
         n = min(n,self.N)
-        imgs = np.asarray([fft.ht2_center(self.particles[i].get()) for i in range(0,self.N, self.N//n)])
+        imgs = pp.asarray([fft.ht2_center(self.particles[i].get()) for i in range(0,self.N, self.N//n)])
         if self.invert_data: imgs *= -1
         imgs = fft.symmetrize_ht(imgs)
-        norm = [np.mean(imgs), np.std(imgs)]
+        norm = [pp.mean(imgs), pp.std(imgs)]
         norm[0] = 0
         log('Normalizing HT by {} +/- {}'.format(*norm))
         return norm
 
     def get(self, i):
+        pp = cp if (self.use_cupy and cp is not None) else np
+
         img = self.particles[i].get()
         if self.window is not None:
             img *= self.window
-        img = fft.ht2_center(img).astype(np.float32)
+        img = fft.ht2_center(img).astype(pp.float32)
         if self.invert_data: img *= -1
         img = fft.symmetrize_ht(img)
         img = (img - self.norm[0])/self.norm[1]
@@ -87,25 +98,29 @@ class LazyMRCData(data.Dataset):
     def __getitem__(self, index):
         return self.get(index), index
 
-def window_mask(D, in_rad, out_rad):
+def window_mask(D, in_rad, out_rad, use_cupy=False):
+    pp = cp if (use_cupy and cp is not None) else np
+
     assert D % 2 == 0
-    x0, x1 = np.meshgrid(np.linspace(-1, 1, D, endpoint=False, dtype=np.float32), 
-                         np.linspace(-1, 1, D, endpoint=False, dtype=np.float32))
+    x0, x1 = pp.meshgrid(pp.linspace(-1, 1, D, endpoint=False, dtype=pp.float32), 
+                         pp.linspace(-1, 1, D, endpoint=False, dtype=pp.float32))
     r = (x0**2 + x1**2)**.5
-    mask = np.minimum(1.0, np.maximum(0.0, 1 - (r-in_rad)/(out_rad-in_rad)))
+    mask = pp.minimum(1.0, pp.maximum(0.0, 1 - (r-in_rad)/(out_rad-in_rad)))
     return mask
 
 class MRCData(data.Dataset):
     '''
     Class representing an .mrcs stack file
     '''
-    def __init__(self, mrcfile, norm=None, keepreal=False, invert_data=False, ind=None, window=True, datadir=None, max_threads=16, window_r=0.85, flog=None):
+    def __init__(self, mrcfile, norm=None, keepreal=False, invert_data=False, ind=None, window=True, datadir=None, max_threads=16, window_r=0.85, flog=None, use_cupy=False):
+        pp = cp if (use_cupy and cp is not None) else np
+
         log = flog if flog is not None else utils.log
         if keepreal:
             raise NotImplementedError
         if ind is not None:
             particles = load_particles(mrcfile, True, datadir=datadir)
-            particles = np.array([particles[i].get() for i in ind])
+            particles = pp.array([particles[i].get() for i in ind])
         else:
             particles = load_particles(mrcfile, False, datadir=datadir)
         N, ny, nx = particles.shape
@@ -124,9 +139,9 @@ class MRCData(data.Dataset):
         if max_threads > 1:
             log(f'Spawning {max_threads} processes')
             with Pool(max_threads) as p:
-                particles = np.asarray(p.map(fft.ht2_center, particles), dtype=np.float32)
+                particles = pp.asarray(p.map(fft.ht2_center, particles), dtype=pp.float32)
         else:
-            particles = np.asarray([fft.ht2_center(img) for img in particles], dtype=np.float32)
+            particles = pp.asarray([fft.ht2_center(img) for img in particles], dtype=pp.float32)
             log('Converted to FFT')
             
         if invert_data: particles *= -1
@@ -137,7 +152,7 @@ class MRCData(data.Dataset):
 
         # normalize
         if norm is None:
-            norm  = [np.mean(particles), np.std(particles)]
+            norm  = [pp.mean(particles), pp.std(particles)]
             norm[0] = 0
         particles = (particles - norm[0])/norm[1]
         log('Normalized HT by {} +/- {}'.format(*norm))
@@ -147,6 +162,7 @@ class MRCData(data.Dataset):
         self.D = particles.shape[1] # ny + 1 after symmetrizing HT
         self.norm = norm
         self.keepreal = keepreal
+        self.use_cupy = use_cupy
         if keepreal:
             self.particles_real = particles_real
             log('Normalized real space images by {}'.format(particles_real.std()))
@@ -164,42 +180,78 @@ class MRCData(data.Dataset):
 class PreprocessedMRCData(data.Dataset):
     '''
     '''
-    def __init__(self, mrcfile, norm=None, ind=None, flog=None):
+    def __init__(self, mrcfile, norm=None, ind=None, flog=None, lazy=False, use_cupy=False):
         log = flog if flog is not None else utils.log
-        particles = load_particles(mrcfile, False)
+        self.use_cupy = use_cupy
+        particles = load_particles(mrcfile, lazy=lazy)
+        self.lazy = lazy
         if ind is not None:
             particles = particles[ind]
-        log(f'Loaded {len(particles)} {particles.shape[1]}x{particles.shape[1]} images')
-        if norm is None:
-            norm  = [np.mean(particles), np.std(particles)]
-            norm[0] = 0
-        particles = (particles - norm[0])/norm[1]
-        log('Normalized HT by {} +/- {}'.format(*norm))
+
         self.particles = particles
         self.N = len(particles)
-        self.D = particles.shape[1] # ny + 1 after symmetrizing HT
+        if self.lazy:
+            self.D = particles[0].get().shape[0] # ny + 1 after symmetrizing HT
+        else:
+            self.D = particles.shape[1] # ny + 1 after symmetrizing HT
+
+        log(f'Loaded {len(particles)} {self.D}x{self.D} images')
+        if norm is None:
+            norm = self.calc_statistic()
+            #norm  = [np.mean(particles), np.std(particles)]
+            norm[0] = 0
+        
+        if not lazy:
+            self.particles = (self.particles - norm[0])/norm[1]
+
+        log('Normalized HT by {} +/- {}'.format(*norm))
         self.norm = norm
 
+    def calc_statistic(self):
+        pp = cp if (self.use_cupy and cp is not None) else np
+
+        if self.lazy:
+            max_size = min(10000, self.N)
+            sample_index = pp.sort(pp.random.choice(pp.arange(self.N), max(int(0.1*self.N), max_size), replace=False))
+            print(f"--lazy mode, sample 10% of samples to calculate standard error...")
+            data = []
+            for d in tqdm(sample_index, leave=False):
+                data.append( self.particles[d].get() )
+            data = pp.stack(data, 0)
+            MEAN, STD = pp.mean(data), pp.std(data)
+            print(f"STD={STD}, MEAN={MEAN}")
+        else:
+            MEAN, STD = pp.mean(self.particles), pp.std(self.particles)
+        return [MEAN, STD]
+        
     def __len__(self):
         return self.N
 
     def __getitem__(self, index):
-        return self.particles[index], index
+        if self.lazy:
+            return (self.particles[index].get() - self.norm[0]) / self.norm[1], index
+        else:
+            return self.particles[index], index
 
     def get(self, index):
-        return self.particles[index]
+        if self.lazy:
+            return (self.particles[index].get() - self.norm[0]) / self.norm[1]
+        else:
+            return self.particles[index]
 
 class TiltMRCData(data.Dataset):
     '''
     Class representing an .mrcs tilt series pair
     '''
-    def __init__(self, mrcfile, mrcfile_tilt, norm=None, keepreal=False, invert_data=False, ind=None, window=True, datadir=None, window_r=0.85, flog=None):
+    def __init__(self, mrcfile, mrcfile_tilt, norm=None, keepreal=False, invert_data=False, ind=None, window=True, datadir=None, window_r=0.85, flog=None, use_cupy=False):
+        pp = cp if (use_cupy and cp is not None) else np
+
         log = flog if flog is not None else utils.log
         if ind is not None:
             particles_real = load_particles(mrcfile, True, datadir)
             particles_tilt_real = load_particles(mrcfile_tilt, True, datadir)
-            particles_real = np.array([particles_real[i].get() for i in ind], dtype=np.float32)
-            particles_tilt_real = np.array([particles_tilt_real[i].get() for i in ind], dtype=np.float32)
+            particles_real = pp.array([particles_real[i].get() for i in ind], dtype=pp.float32)
+            particles_tilt_real = pp.array([particles_tilt_real[i].get() for i in ind], dtype=pp.float32)
         else:
             particles_real = load_particles(mrcfile, False, datadir)
             particles_tilt_real = load_particles(mrcfile_tilt, False, datadir)
@@ -218,8 +270,8 @@ class TiltMRCData(data.Dataset):
             particles_tilt_real *= m 
 
         # compute HT
-        particles = np.asarray([fft.ht2_center(img) for img in particles_real]).astype(np.float32)
-        particles_tilt = np.asarray([fft.ht2_center(img) for img in particles_tilt_real]).astype(np.float32)
+        particles = pp.asarray([fft.ht2_center(img) for img in particles_real]).astype(pp.float32)
+        particles_tilt = pp.asarray([fft.ht2_center(img) for img in particles_tilt_real]).astype(pp.float32)
         if invert_data: 
             particles *= -1
             particles_tilt *= -1
@@ -230,7 +282,7 @@ class TiltMRCData(data.Dataset):
 
         # normalize
         if norm is None:
-            norm  = [np.mean(particles), np.std(particles)]
+            norm  = [pp.mean(particles), pp.std(particles)]
             norm[0] = 0
         particles = (particles - norm[0])/norm[1]
         particles_tilt = (particles_tilt - norm[0])/norm[1]
@@ -242,6 +294,7 @@ class TiltMRCData(data.Dataset):
         self.N = N
         self.D = particles.shape[1]
         self.keepreal = keepreal
+        self.use_cupy = use_cupy
         if keepreal:
             self.particles_real = particles_real
             self.particles_tilt_real = particles_tilt_real

--- a/cryodrgn/fft.py
+++ b/cryodrgn/fft.py
@@ -1,23 +1,37 @@
 import numpy as np
+try:
+    import cupy as cp
+except:
+    cp = None
 
 def fft2_center(img):
-    return np.fft.fftshift(np.fft.fft2(np.fft.fftshift(img,axes=(-1,-2))),axes=(-1,-2))
+    pp = np if isinstance(img, np.ndarray) else cp
+
+    return pp.fft.fftshift(pp.fft.fft2(pp.fft.fftshift(img,axes=(-1,-2))),axes=(-1,-2))
 
 def fftn_center(img):
-    return np.fft.fftshift(np.fft.fftn(np.fft.fftshift(img)))
+    pp = np if isinstance(img, np.ndarray) else cp
+
+    return pp.fft.fftshift(pp.fft.fftn(pp.fft.fftshift(img)))
 
 def ifftn_center(V):
-    V = np.fft.ifftshift(V)
-    V = np.fft.ifftn(V)
-    V = np.fft.ifftshift(V)
+    pp = np if isinstance(V, np.ndarray) else cp
+
+    V = pp.fft.ifftshift(V)
+    V = pp.fft.ifftn(V)
+    V = pp.fft.ifftshift(V)
     return V
 
 def ht2_center(img):
+    pp = np if isinstance(img, np.ndarray) else cp
+
     f = fft2_center(img)
     return f.real-f.imag
 
 def htn_center(img):
-    f = np.fft.fftshift(np.fft.fftn(np.fft.fftshift(img)))
+    pp = np if isinstance(img, np.ndarray) else cp
+
+    f = pp.fft.fftshift(pp.fft.fftn(pp.fft.fftshift(img)))
     return f.real-f.imag
 
 def iht2_center(img):
@@ -26,13 +40,17 @@ def iht2_center(img):
     return img.real - img.imag
 
 def ihtn_center(V):
-    V = np.fft.fftshift(V)
-    V = np.fft.fftn(V)
-    V = np.fft.fftshift(V)
-    V /= np.product(V.shape)
+    pp = np if isinstance(V, np.ndarray) else cp
+    
+    V = pp.fft.fftshift(V)
+    V = pp.fft.fftn(V)
+    V = pp.fft.fftshift(V)
+    V /= pp.product(V.shape)
     return V.real - V.imag
 
 def symmetrize_ht(ht, preallocated=False):
+    pp = np if isinstance(ht, np.ndarray) else cp
+    
     if preallocated:
         D = ht.shape[-1] - 1
         sym_ht = ht
@@ -42,7 +60,8 @@ def symmetrize_ht(ht, preallocated=False):
         assert len(ht.shape) == 3
         D = ht.shape[-1]
         B = ht.shape[0]
-        sym_ht = np.empty((B,D+1,D+1),dtype=ht.dtype)
+        sym_ht = pp.empty((B,D+1,D+1),dtype=ht.dtype)
+        #print("sym_ht:", type(sym_ht))
         sym_ht[:,0:-1,0:-1] = ht
     assert D % 2 == 0
     sym_ht[:,-1,:] = sym_ht[:,0] # last row is the first row

--- a/cryodrgn/fft.py
+++ b/cryodrgn/fft.py
@@ -1,7 +1,7 @@
 import numpy as np
 try:
     import cupy as cp
-except:
+except ImportError:
     cp = None
 
 def fft2_center(img):
@@ -61,7 +61,6 @@ def symmetrize_ht(ht, preallocated=False):
         D = ht.shape[-1]
         B = ht.shape[0]
         sym_ht = pp.empty((B,D+1,D+1),dtype=ht.dtype)
-        #print("sym_ht:", type(sym_ht))
         sym_ht[:,0:-1,0:-1] = ht
     assert D % 2 == 0
     sym_ht[:,-1,:] = sym_ht[:,0] # last row is the first row


### PR DESCRIPTION
I propose to add two features for CryoDRGN to reduce the memory usage in train_vae and speed up in preprocess. 

1. Add a lazy parameter to `dataset.PreprocessedMRCData.__init__` class. The statistic values (mean and std) can be obtained from a randomly sampled subset of 10% of data. This can avoid storing all the data in memory. To accelerate disk IO, I increased the num_workers in Dataloader (in train_vae.py). I compared the memory usage and speed in a dataset with 503,557 256*256 particles.
### Parameter settings
**--lazy version**
```bash
CUDA_VISIBLE_DEVICES=0,1 python ${CRYODRGN}/cryodrgn/commands/train_vae.py \
        particles.256.ft.txt \
        --poses poses.pkl \
        --ctf ctf.pkl \
        -o outputs_256 \
        --preprocessed \
        --zdim 8 \
        --enc-dim 1024 \
        --enc-layers 3 \
        --dec-dim 1024  \
        --dec-layers 3 \
        --max-threads 8 \
        --multigpu \
        --lazy
```
**no --lazy version**
```bash
CUDA_VISIBLE_DEVICES=0,1 python ${CRYODRGN}/cryodrgn/commands/train_vae.py \
        particles.256.ft.txt \
        --poses poses.pkl \
        --ctf ctf.pkl \
        -o outputs_256 \
        --preprocessed \
        --zdim 8 \
        --enc-dim 1024 \
        --enc-layers 3 \
        --dec-dim 1024  \
        --dec-layers 3 \
        --max-threads 8 \
        --multigpu
```
**Comparison**
|          | Speed in training  | Memory in training |
|----------|---------------------|-------|
| --lazy version | 10.7s/2000 samples  | 16G |
| no --lazy version    | 10.3s/2000 samples  | 130G |

2. Add a --cupy option to preprocess.py and replace all numpy FFT operations with cupy version. I test it in a dataset with ~100,000 particles (raw D=440). The numpy version took 16m16s on CPU (--max-threads 16), the cupy version took 9min50s on single 2090 Ti.

### Parameter settings
**numpy version**
```bash
python ${CRYODRGN}/cryodrgn/commands/preprocess.py \
        ${CS_FULL_PATH} \
        --datadir ${PARTICLES_FULL_PATH} \
        -D 256 \
        --max-threads 16 \
        -o particles.256.mrcs \
        --chunk 25000 \
        -b 5000
```

**cupy version**
```bash
CUDA_VISIBLE_DEVICES=0 python ${CRYODRGN}/cryodrgn/commands/preprocess.py \
        ${CS_FULL_PATH} \
        --datadir ${PARTICLES_FULL_PATH} \
        -D 256 \
        --max-threads 16 \
        -o particles.256.mrcs \
        --chunk 25000 \
        -b 2500 \
        --use_cupy
```