### PR TITLE
pyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release 
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  run_tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Upgrade setuptools/build
+        run: |
+          pip3 install wheel --upgrade
+          pip3 install setuptools --upgrade
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Release to pypi
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+        run: |
+          python -m pip install --upgrade build
+          python -m build .
+          python -m pip install --upgrade twine
+          twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ To install cryoDRGN, git clone the source code and install the following depende
     # Clone source code and install
     git clone https://github.com/zhonge/cryodrgn.git
     cd cryodrgn
-    git checkout 1.1.0 # or latest version
     pip install .
 
 A detailed installation and testing guide is provided here: https://www.notion.so/cryoDRGN-installation-with-anaconda-4cff0367d9b241bb8d902efe339d01e6


### PR DESCRIPTION
This workflow should automatically upload a new version of `cryoDRGN` up on pyPI, every time we decide to make a new release. To make this work, we need a couple of additional steps:

- Create an account on pypi.org
- Go to the account settings page and create a new API token.
- Copy the API token
- Go to the `cryodrgn` github page -> Settings -> Secrets -> Actions. 
- Add a new repository secret, with the name `PYPI_API_TOKEN` and the value the token copied above.

This should work unless I've made a mistake. I guess we'll find out when we make the next (`1.1.1` release).