### PR TITLE
Bug fix when reloading a model instantiated using --multigpu

### DIFF
--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -599,7 +599,12 @@ def save_checkpoint(
     with open(out_poses, "wb") as f:
         rot, trans = search_pose
         # When saving translations, save in box units (fractional)
-        trans /= model.lattice.D
+        D = (
+            model.module.lattice.D
+            if isinstance(model, nn.DataParallel)
+            else model.lattice.D
+        )
+        trans /= D
         pickle.dump((rot, trans), f)
 
 
@@ -821,6 +826,17 @@ def main(args):
         )
     )
 
+    # parallelize
+    if args.multigpu and torch.cuda.device_count() > 1:
+        log(f"Using {torch.cuda.device_count()} GPUs!")
+        args.batch_size *= torch.cuda.device_count()
+        log(f"Increasing batch size to {args.batch_size}")
+        model = nn.DataParallel(model)
+    elif args.multigpu:
+        log(
+            f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
+        )
+
     if args.equivariance:
         assert args.equivariance > 0, "Regularization weight must be positive"
         equivariance_lambda = LinearSchedule(
@@ -847,20 +863,14 @@ def main(args):
                 trans <= 1
             ), "ERROR: Old pose format detected. Translations must be in units of fraction of box."
             # Convert translations to pixel units to feed back to the model
-            sorted_poses = (rot, trans * model.lattice.D)
+            D = (
+                model.module.lattice.D
+                if isinstance(model, nn.DataParallel)
+                else model.lattice.D
+            )
+            sorted_poses = (rot, trans * D)
     else:
         start_epoch = 0
-
-    # parallelize
-    if args.multigpu and torch.cuda.device_count() > 1:
-        log(f"Using {torch.cuda.device_count()} GPUs!")
-        args.batch_size *= torch.cuda.device_count()
-        log(f"Increasing batch size to {args.batch_size}")
-        model = nn.DataParallel(model)
-    elif args.multigpu:
-        log(
-            f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
-        )
 
     if args.pose_model_update_freq:
         assert not args.multigpu, "TODO"


### PR DESCRIPTION
There were 2 issues in loading a checkpointed model when `--multigpu` was specified on model creation:
 - The image size `D` of the model cannot be ascertained through `model.lattice.D` but has to be reached-in by doing `model.module.lattice.D`, since `model` is a `DataParallel` object. This was a bug introduced in my last commit.
 - Loading such a module will fail anyway because the state dictionary created during check-pointing has keys like `module.encoder.main.6.bias` which can only be loaded if the decision to instantiate a `DataParallel` object has been made *before* loading the checkpointed-state dict, not after.
 
 The fix here fixes these 2 issues, but means that a multi-gpu model has to be re-loaded again in a multi-gpu set up. This seems reasonable to me. A more robust solution would not have this restriction.
 
 