### PR TITLE
voxel decoder and mlp+voxel decoder for train_vae

### DIFF
--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -24,7 +24,7 @@ def add_args(parser):
     )
     parser.add_argument(
         "epoch",
-        type=int,
+        type=str,
         help="Epoch number N to analyze (0-based indexing, corresponding to z.N.pkl, weights.N.pkl)",
     )
     parser.add_argument("--device", type=int, help="Optionally specify CUDA device")


### PR DESCRIPTION
Implemented voxel-based decoding.

1. For homogeneous reconstruction, the optimization of voxel decoder is much worse than MLP. But since it's a convex problem you can optimize it with L-BFGS and get great reconstruction much faster than regular cryodrgn.
```
# MLP VAE
cryodrgn train_vae data/hand.mrcs  -o output/toy_recon_vae --lr .0001 --seed 0 --poses data/hand_rot.pkl --pe-type gaussian --zdim 10
2022-12-13 12:43:46     # =====> Epoch: 20 Average gen loss = 0.00429948, KLD = 18.573173, total loss = 0.004878; Finished in 0:00:00.446518

# MLP
cryodrgn train_nn data/hand.mrcs  -o output/toy_recon_vae --lr .0001 --seed 0 --poses data/hand_rot.pkl --pe-type gaussian
2022-12-13 12:51:02     # =====> Epoch: 20 Average loss = 0.0106838; Finished in 0:00:00.077371

# voxels
cryodrgn train_nn data/hand.mrcs  -o output/toy_recon_vae --lr .0001 --seed 0 --poses data/hand_rot.pkl --pe-type gaussian --dec-type voxel
2022-12-13 12:42:22     # =====> Epoch: 20 Average loss = 0.0206206; Finished in 0:00:00.047862

# voxels + L-BFGS
cryodrgn train_nn data/hand.mrcs  -o output/toy_recon_vae --lr .0001 --seed 0 --poses data/hand_rot.pkl --pe-type gaussian --dec-type voxel --lbfgs --lr 1 --no-epochs 1
2022-12-13 12:52:00     # =====> Epoch: 1 Average loss = 0.000518009; Finished in 0:00:00.039620
```

For heterogeneous reconstruction, I make a hybrid model (`dec-type=voxel+mlp`) that's a sum of voxel and mlp decoders. I pretrain the voxel array model with L-BFGS, and then train the residual jointly. It gets high-quality reconstructions very quickly (e.g. 20 minutes for a D=320 grid), but doesn't capture heterogeneity very well.

Results on a 128-grid ribosome in `01_voxel+mlp`. Results on a 320-grid 80S ribosome in `/projects/ZHONGE/alerer/02_voxel_80S_ribo`.