### PR TITLE
Dynamic version on docs, set by GH Actions as an envvar

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Setup Envvars
+        run: |
+            if [[ $GITHUB_REF = "refs/tags/"* ]] ; then echo "CRYODRGN_VERSION=${GITHUB_REF/refs\/tags\//}" ; else echo "CRYODRGN_VERSION=" ; fi >> $GITHUB_ENV
+
       - name: Build docs
         run: |
           # Unless we add a .nojekyll to the base of the deployment folder, the underscores in foldernames

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,13 +3,15 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "CryoDRGN"
-copyright = "2022, Ellen Zhong"
+copyright = "2023, Ellen Zhong"
 author = "Ellen Zhong"
-release = "1.1.1"
+release = os.environ.get("CRYODRGN_VERSION", "")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
When building locally, one can set the version number rendered in the HTML by setting an envvar:
```
cd docs
CRYODRGN_VERSION=1.2.3 make html
```
This envvar is set up automatically by the Github workflow by inspecting the git tags, and thus the correct version will be used when auto-generating the documentation online.