### PR TITLE
Added cryoDRGN2 quickstart page to docs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-select = B950
 extend-ignore = E203,E501
 max-complexity = 99
 max-line-length = 88

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Setup Envvars
+        run: |
+            if [[ $GITHUB_REF = "refs/tags/"* ]] ; then echo "CRYODRGN_VERSION=${GITHUB_REF/refs\/tags\//}" ; else echo "CRYODRGN_VERSION=" ; fi >> $GITHUB_ENV
+
       - name: Build docs
         run: |
           # Unless we add a .nojekyll to the base of the deployment folder, the underscores in foldernames

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Pyright
         run: |
+          pyright --version
           pyright
 
       - name: Pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - '*'
 
 jobs:
-  run_tests:
+  release:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     branches: [ master ]
-  tags:
-    - '*'
+    tags:
+      - '*'
 
 jobs:
   run_tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  tags:
+    - '*'
 
 jobs:
   run_tests:

--- a/README.md
+++ b/README.md
@@ -27,16 +27,44 @@ A quick start is provided below.
 
 Post any questions as an Github issue or to our google group: https://groups.google.com/g/cryodrgn.
 
-## New in Version 1.x
+## New in Version 2.2
 
-### Version 1.1
+* The official cryoDRGN2 release with new tools available for ab initio homogeneous and heterogeneous reconstruction:
+
+```
+(cryodrgn) $ cryodrgn abinit_homo -h
+(cryodrgn) $ cryodrgn abinit_het -h
+```
+
+* New utility script for writing cryoSPARC `.cs`/`.csg` files [to faciliate reimporting data into cryoSPARC](https://github.com/zhonge/cryodrgn/issues/150#issuecomment-1465094751):
+
+```
+(cryodrgn) $ cryodrgn_utils write_cs
+```
+
+* [Improved plotting](https://github.com/zhonge/cryodrgn/issues/219) in cryodrgn analyze
+
+* Many codebase improvements with open-source software development practices (e.g. continuous integration tests, black, flake8, pyright, logging, and PyPi packaging).
+
+* Upcoming in the next minor version (v2.3):
+
+	* We are working on a major refactor of data loading for handling large datasets. This will entail an API change for the mrc.py library module
+
+
+### Previous versions
+
+
+<details><summary>Version 1.1.x</summary>
 
 Updated default parameters for `cryodrgn train_vae` with modified positional encoding, larger model architecture, and accelerated mixed-precision training turned on by default:
 * Mixed precision training is now turned on by default (Use `--no-amp` to revert to single precision training)
 * Encoder/decoder architecture is now 1024x3 by default (Use `--enc-dim 256` and `--dec-dim 256` to revert)
 * Gaussian Fourier featurization for faster training and higher resolution density maps (Use `--pe-type geom_lowf` to revert)
 
-### Version 1.0
+</details>
+
+
+<details><summary>Version 1.0.x</summary>
 
 The official version 1.0 release. This version introduces several new tools for analysis of the reconstructed ensembles, and adds functionality for calling utility scripts with `cryodrgn_utils <command>`.
 
@@ -46,7 +74,7 @@ The official version 1.0 release. This version introduces several new tools for 
 * NEW: `cryodrgn_utils write_star` for converting cryoDRGN particle selections to `.star` files
 * Add pytorch native mixed precision training and fix support for pytorch 1.9+
 
-### Previous versions
+</details>
 
 <details><summary>Version 0.3.4</summary>
 

--- a/analysis_scripts/fsc.py
+++ b/analysis_scripts/fsc.py
@@ -1,13 +1,12 @@
 """Compute FSC between two volumes"""
 
 import argparse
-
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
+from cryodrgn import fft, mrc
 
-from cryodrgn import fft, mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -45,7 +44,7 @@ def main(args):
     vol1 = fft.fftn_center(vol1)
     vol2 = fft.fftn_center(vol2)
 
-    # log(r[D//2, D//2, D//2:])
+    # logger.info(r[D//2, D//2, D//2:])
     prev_mask = np.zeros((D, D, D), dtype=bool)
     fsc = [1.0]
     for i in range(1, D // 2):
@@ -63,15 +62,15 @@ def main(args):
     if args.o:
         np.savetxt(args.o, res)
     else:
-        log(res)
+        logger.info(res)
 
     w = np.where(fsc < 0.5)
     if w:
-        log("0.5: {}".format(1 / x[w[0]] * args.Apix))
+        logger.info("0.5: {}".format(1 / x[w[0]] * args.Apix))
 
     w = np.where(fsc < 0.143)
     if w:
-        log("0.143: {}".format(1 / x[w[0]] * args.Apix))
+        logger.info("0.143: {}".format(1 / x[w[0]] * args.Apix))
 
     if args.plot:
         plt.plot(x, fsc)

--- a/cryodrgn/__init__.py
+++ b/cryodrgn/__init__.py
@@ -17,7 +17,10 @@ logging.config.dictConfig(
     {
         "version": 1,
         "formatters": {
-            "standard": {"format": "%(asctime)s %(message)s (%(filename)s:%(lineno)d)"}
+            "standard": {
+                "format": "(%(levelname)s) (%(filename)s) (%(asctime)s) %(message)s",
+                "datefmt": "%d-%b-%y %H:%M:%S",
+            }
         },
         "handlers": {
             "default": {

--- a/cryodrgn/__init__.py
+++ b/cryodrgn/__init__.py
@@ -16,10 +16,12 @@ _ROOT = os.path.abspath(os.path.dirname(__file__))
 logging.config.dictConfig(
     {
         "version": 1,
-        "formatters": {"standard": {"format": "%(asctime)s     %(message)s"}},
+        "formatters": {
+            "standard": {"format": "%(asctime)s %(message)s (%(filename)s:%(lineno)d)"}
+        },
         "handlers": {
             "default": {
-                "level": "INFO",
+                "level": "NOTSET",
                 "formatter": "standard",
                 "class": "logging.StreamHandler",
                 "stream": "ext://sys.stdout",

--- a/cryodrgn/__init__.py
+++ b/cryodrgn/__init__.py
@@ -1,4 +1,6 @@
 import os
+import logging.config
+
 
 # The _version.py file is managed by setuptools-scm
 #   and is not in version control.
@@ -9,3 +11,20 @@ except ModuleNotFoundError:
     __version__ = "src"
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
+
+
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "formatters": {"standard": {"format": "%(asctime)s     %(message)s"}},
+        "handlers": {
+            "default": {
+                "level": "INFO",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "loggers": {"": {"handlers": ["default"], "level": "INFO"}},
+    }
+)

--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -1,5 +1,6 @@
 import argparse
 import re
+import logging
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure, Axes
 import numpy as np
@@ -12,7 +13,8 @@ from sklearn.manifold import TSNE
 from sklearn.mixture import GaussianMixture
 from typing import Optional, Union, Tuple, List
 from cryodrgn.commands import eval_vol
-from cryodrgn.utils import log
+
+logger = logging.getLogger(__name__)
 
 
 def parse_loss(f: str) -> np.ndarray:
@@ -36,8 +38,8 @@ def parse_loss(f: str) -> np.ndarray:
 def run_pca(z: np.ndarray) -> Tuple[np.ndarray, PCA]:
     pca = PCA(z.shape[1])
     pca.fit(z)
-    log("Explained variance ratio:")
-    log(pca.explained_variance_ratio_)
+    logger.info("Explained variance ratio:")
+    logger.info(pca.explained_variance_ratio_)
     pc = pca.transform(z)
     return pc, pca
 
@@ -83,7 +85,9 @@ def run_tsne(
     z: np.ndarray, n_components: int = 2, perplexity: float = 1000
 ) -> np.ndarray:
     if len(z) > 10000:
-        log("WARNING: {} datapoints > {}. This may take awhile.".format(len(z), 10000))
+        logger.warning(
+            "WARNING: {} datapoints > {}. This may take awhile.".format(len(z), 10000)
+        )
     z_embedded = TSNE(n_components=n_components, perplexity=perplexity).fit_transform(z)
     return z_embedded
 

--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -225,6 +225,28 @@ def get_ind_for_cluster(
 # PLOTTING
 
 
+def _get_chimerax_colors(K: int) -> List:
+    colors = [
+        "#b2b2b2",
+        "#ffffb2",
+        "#b2ffff",
+        "#b2b2ff",
+        "#ffb2ff",
+        "#ffb2b2",
+        "#b2ffb2",
+        "#e5bf99",
+        "#99bfe5",
+        "#cccc99",
+    ]
+    if K < 10:
+        colors = colors[0:K]
+    else:
+        colors *= K // 10
+        if K % 10:
+            colors += colors[0 : (K % 10)]
+    return colors
+
+
 def _get_colors(K: int, cmap: Optional[str] = None) -> List:
     if cmap is not None:
         cm = plt.get_cmap(cmap)
@@ -244,8 +266,9 @@ def scatter_annotate(
     labels: Optional[np.ndarray] = None,
     alpha: Union[float, np.ndarray, None] = 0.1,
     s: Union[float, np.ndarray, None] = 1,
+    colors: Optional[list] = None,
 ) -> Tuple[Figure, Axes]:
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=(4, 4))
     plt.scatter(x, y, alpha=alpha, s=s, rasterized=True)
 
     # plot cluster centers
@@ -253,7 +276,9 @@ def scatter_annotate(
         assert centers is None
         centers = np.array([[x[i], y[i]] for i in centers_ind])
     if centers is not None:
-        plt.scatter(centers[:, 0], centers[:, 1], c="k")
+        if colors is None:
+            colors = "k"
+        plt.scatter(centers[:, 0], centers[:, 1], c=colors, edgecolor="black")
     if annotate:
         assert centers is not None
         if labels is None:
@@ -271,15 +296,18 @@ def scatter_annotate_hex(
     centers_ind: Optional[np.ndarray] = None,
     annotate: bool = True,
     labels: Optional[np.ndarray] = None,
+    colors: Optional[List] = None,
 ) -> sns.JointGrid:
-    g = sns.jointplot(x=x, y=y, kind="hex")
+    g = sns.jointplot(x=x, y=y, kind="hex", height=4)
 
     # plot cluster centers
     if centers_ind is not None:
         assert centers is None
         centers = np.array([[x[i], y[i]] for i in centers_ind])
     if centers is not None:
-        g.ax_joint.scatter(centers[:, 0], centers[:, 1], color="k", edgecolor="grey")
+        if colors is None:
+            colors = "k"
+        g.ax_joint.scatter(centers[:, 0], centers[:, 1], c=colors, edgecolor="black")
     if annotate:
         assert centers is not None
         if labels is None:

--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -238,12 +238,7 @@ def _get_chimerax_colors(K: int) -> List:
         "#99bfe5",
         "#cccc99",
     ]
-    if K < 10:
-        colors = colors[0:K]
-    else:
-        colors *= K // 10
-        if K % 10:
-            colors += colors[0 : (K % 10)]
+    colors = [colors[i % len(colors)] for i in range(K)]
     return colors
 
 
@@ -266,7 +261,7 @@ def scatter_annotate(
     labels: Optional[np.ndarray] = None,
     alpha: Union[float, np.ndarray, None] = 0.1,
     s: Union[float, np.ndarray, None] = 1,
-    colors: Optional[list] = None,
+    colors: Union[list, str, None] = None,
 ) -> Tuple[Figure, Axes]:
     fig, ax = plt.subplots(figsize=(4, 4))
     plt.scatter(x, y, alpha=alpha, s=s, rasterized=True)
@@ -296,7 +291,7 @@ def scatter_annotate_hex(
     centers_ind: Optional[np.ndarray] = None,
     annotate: bool = True,
     labels: Optional[np.ndarray] = None,
-    colors: Optional[List] = None,
+    colors: Union[list, str, None] = None,
 ) -> sns.JointGrid:
     g = sns.jointplot(x=x, y=y, kind="hex", height=4)
 

--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -4,6 +4,7 @@ import logging
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure, Axes
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import seaborn as sns
 from scipy.spatial.distance import cdist
@@ -52,7 +53,7 @@ def get_pc_traj(
     start: Optional[float],
     end: Optional[float],
     percentiles: Optional[np.ndarray] = None,
-) -> np.ndarray:
+) -> npt.NDArray[np.float32]:
     """
     Create trajectory along specified principal component
 
@@ -163,7 +164,7 @@ def cluster_gmm(
 
 def get_nearest_point(
     data: np.ndarray, query: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[npt.NDArray[np.float32], np.ndarray]:
     """
     Find closest point in @data to @query
     Return datapoint, index

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -614,8 +614,7 @@ def save_checkpoint(
             D = _model.lattice.D
         else:
             D = model.lattice.D
-        trans /= D
-        pickle.dump((rot, trans), f)
+        pickle.dump((rot, trans / D), f)
 
 
 def save_config(args, dataset, lattice, model, out_config):

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -685,6 +685,9 @@ def get_latest(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -1126,6 +1129,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -497,8 +497,8 @@ def train(
 
     if use_tilt:
         gen_loss = 0.5 * F.mse_loss(gen_slice(rot), y) + 0.5 * F.mse_loss(
-            gen_slice(bnb.tilt @ rot), yt  # type: ignore
-        )  # noqa: F821
+            gen_slice(bnb.tilt @ rot), yt  # type: ignore  # noqa: F821
+        )
     else:
         gen_loss = F.mse_loss(gen_slice(rot), y)
 

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import pickle
 import sys
+import logging
 from datetime import datetime as dt
 import numpy as np
 import torch
@@ -21,8 +22,7 @@ from cryodrgn.losses import EquivarianceLoss
 from cryodrgn.models import HetOnlyVAE, unparallelize
 from cryodrgn.pose_search import PoseSearch
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -57,7 +57,7 @@ def add_args(parser):
         help="Logging interval in N_IMGS (default: %(default)s)",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increaes verbosity"
+        "-v", "--verbose", action="store_true", help="Increase verbosity"
     )
     parser.add_argument(
         "--seed", type=int, default=np.random.randint(0, 100000), help="Random seed"
@@ -504,8 +504,8 @@ def train(
 
     kld = -0.5 * torch.mean(1 + z_logvar - z_mu.pow(2) - z_logvar.exp())
     if torch.isnan(kld):
-        log(z_mu[0])
-        log(z_logvar[0])
+        logger.info(z_mu[0])
+        logger.info(z_logvar[0])
         raise RuntimeError("KLD is nan")
 
     if beta_control is None:
@@ -671,16 +671,16 @@ def sort_poses(poses):
     return (rot,)
 
 
-def get_latest(args, flog):
-    flog("Detecting latest checkpoint...")
+def get_latest(args):
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     i = args.load.split(".")[-2]
     args.load_poses = f"{args.outdir}/pose.{i}.pkl"
     assert os.path.exists(args.load_poses)
-    flog(f"Loading {args.load_poses}")
+    logger.info(f"Loading {args.load_poses}")
     return args
 
 
@@ -688,15 +688,13 @@ def main(args):
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -705,9 +703,9 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        log("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # set beta schedule
     try:
@@ -720,13 +718,13 @@ def main(args):
 
     # load index filter
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
 
     # load dataset
-    flog(f"Loading dataset from {args.particles}")
+    logger.info(f"Loading dataset from {args.particles}")
     if args.tilt is None:
         tilt = None
         args.use_real = args.encode_mode == "conv"
@@ -750,15 +748,12 @@ def main(args):
                 window=args.window,
                 datadir=args.datadir,
                 window_r=args.window_r,
-                flog=flog,
             )
         elif args.preprocessed:
-            flog(
+            logger.info(
                 "Using preprocessed inputs. Ignoring any --window/--invert-data options"
             )
-            data = dataset.PreprocessedMRCData(
-                args.particles, norm=args.norm, ind=ind, flog=flog
-            )
+            data = dataset.PreprocessedMRCData(args.particles, norm=args.norm, ind=ind)
         else:
             data = dataset.MRCData(
                 args.particles,
@@ -770,7 +765,6 @@ def main(args):
                 datadir=args.datadir,
                 max_threads=args.max_threads,
                 window_r=args.window_r,
-                flog=flog,
             )
 
     # Tilt series data -- lots of unsupported features
@@ -792,7 +786,6 @@ def main(args):
             keepreal=args.use_real,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = torch.tensor(utils.xrot(args.tilt_deg).astype(np.float32), device=device)
     Nimg = data.N
@@ -803,7 +796,7 @@ def main(args):
 
     # load ctf
     if args.ctf is not None:
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -829,8 +822,8 @@ def main(args):
 
     model = make_model(args, lattice, enc_mask, in_dim)
     model.to(device)
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
@@ -838,12 +831,12 @@ def main(args):
 
     # parallelize
     if args.multigpu and torch.cuda.device_count() > 1:
-        log(f"Using {torch.cuda.device_count()} GPUs!")
+        logger.info(f"Using {torch.cuda.device_count()} GPUs!")
         args.batch_size *= torch.cuda.device_count()
-        log(f"Increasing batch size to {args.batch_size}")
+        logger.info(f"Increasing batch size to {args.batch_size}")
         model = DataParallel(model)
     elif args.multigpu:
-        log(
+        logger.warning(
             f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
         )
 
@@ -859,12 +852,12 @@ def main(args):
     optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)
 
     if args.load == "latest":
-        args = get_latest(args, flog)
+        args = get_latest(args)
 
     sorted_poses = []
     if args.load:
         args.pretrain = 0
-        flog("Loading checkpoint from {}".format(args.load))
+        logger.info("Loading checkpoint from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -918,7 +911,7 @@ def main(args):
 
     # pretrain decoder with random poses
     global_it = 0
-    flog("Using random poses for {} iterations".format(args.pretrain))
+    logger.info("Using random poses for {} iterations".format(args.pretrain))
     while global_it < args.pretrain:
         for batch in data_iterator:
             global_it += len(batch[0])
@@ -929,13 +922,13 @@ def main(args):
             )
             loss = pretrain(model, lattice, optim, batch, tilt=ps.tilt, zdim=args.zdim)
             if global_it % args.log_interval == 0:
-                flog(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
+                logger.info(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
             if global_it > args.pretrain:
                 break
 
     # reset model after pretraining
     if args.reset_optim_after_pretrain:
-        flog(">> Resetting optim after pretrain")
+        logger.info(">> Resetting optim after pretrain")
         optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)
 
     # training loop
@@ -965,17 +958,17 @@ def main(args):
                 L_model = ps.Lmax
 
         if args.reset_model_every and (epoch - 1) % args.reset_model_every == 0:
-            flog(">> Resetting model")
+            logger.info(">> Resetting model")
             model = make_model(args, lattice, enc_mask, in_dim)
 
         if args.reset_optim_every and (epoch - 1) % args.reset_optim_every == 0:
-            flog(">> Resetting optim")
+            logger.info(">> Resetting optim")
             optim = torch.optim.Adam(
                 model.parameters(), lr=args.lr, weight_decay=args.wd
             )
 
         if epoch % args.ps_freq != 0:
-            flog("Using previous iteration poses")
+            logger.info("Using previous iteration poses")
         for batch in data_iterator:
             ind = batch[-1]
             ind_np = ind.cpu().numpy()
@@ -1036,7 +1029,7 @@ def main(args):
                     if eq_loss is not None and lamb is not None
                     else ""
                 )
-                log(
+                logger.info(
                     f"# [Train Epoch: {epoch+1}/{num_epochs}] [{batch_it}/{Nimg} images] gen loss={gen_loss:.4f}, "
                     f"kld={kld:.4f}, beta={beta:.4f}, {eq_log}loss={loss:.4f}"
                 )
@@ -1046,7 +1039,7 @@ def main(args):
             if args.equivariance
             else ""
         )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average gen loss = {:.4}, KLD = {:.4f}, {}total loss = {:.4f}; Finished in {}".format(
                 epoch + 1,
                 gen_loss_accum / Nimg,
@@ -1125,7 +1118,7 @@ def main(args):
             )
 
         td = dt.now() - t1
-        flog(
+        logger.info(
             "Finished in {} ({} per epoch)".format(td, td / (num_epochs - start_epoch))
         )
 
@@ -1133,5 +1126,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -447,6 +447,9 @@ def make_model(args, D: int):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -728,6 +731,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -286,8 +286,7 @@ def save_checkpoint(
     with open(out_poses, "wb") as f:
         rot, trans = pose
         # When saving translations, save in box units (fractional)
-        trans /= model.D
-        pickle.dump((rot, trans), f)
+        pickle.dump((rot, trans / model.D), f)
 
 
 def pretrain(model, lattice, optim, batch, tilt=None):

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -5,7 +5,6 @@ Homogeneous NN reconstruction with hierarchical pose optimization
 import argparse
 import os
 import pickle
-import signal
 import sys
 from datetime import datetime as dt
 import logging
@@ -20,14 +19,6 @@ from cryodrgn.lattice import Lattice
 from cryodrgn.pose_search import PoseSearch
 
 logger = logging.getLogger(__name__)
-
-# def debug_signal_handler(signal, frame):
-#     import pdb
-
-#     pdb.set_trace()
-
-
-# signal.signal(signal.SIGINT, debug_signal_handler)
 
 
 def add_args(parser):

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -8,7 +8,7 @@ import pickle
 import signal
 import sys
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
 import torch.nn as nn
@@ -19,9 +19,7 @@ from cryodrgn import ctf, dataset, lie_tools, models, mrc, utils
 from cryodrgn.lattice import Lattice
 from cryodrgn.pose_search import PoseSearch
 
-log = utils.log
-vlog = utils.vlog
-
+logger = logging.getLogger(__name__)
 
 # def debug_signal_handler(signal, frame):
 #     import pdb
@@ -419,17 +417,17 @@ def train(
     return loss.item(), save_pose, base_pose
 
 
-def get_latest(args, flog):
+def get_latest(args):
     # assumes args.num_epochs > latest checkpoint
-    flog("Detecting latest checkpoint...")
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     i = args.load.split(".")[-2]
     args.load_poses = f"{args.outdir}/pose.{i}.pkl"
     assert os.path.exists(args.load_poses)  # Might need to relax this assert
-    flog(f"Loading {args.load_poses}")
+    logger.info(f"Loading {args.load_poses}")
     return args
 
 
@@ -452,15 +450,14 @@ def main(args):
     t1 = dt.now()
     if not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -469,13 +466,13 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        flog("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # load the particles
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         args.ind = pickle.load(open(args.ind, "rb"))
     if args.tilt is None:
         data = dataset.MRCData(
@@ -485,7 +482,6 @@ def main(args):
             ind=args.ind,
             window=args.window,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = None
     else:
@@ -497,7 +493,6 @@ def main(args):
             ind=args.ind,
             window=args.window,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = torch.tensor(utils.xrot(args.tilt_deg).astype(np.float32), device=device)
     D = data.D
@@ -505,7 +500,7 @@ def main(args):
 
     # load ctf
     if args.ctf is not None:
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[args.ind]
@@ -544,8 +539,8 @@ def main(args):
             t_yshift=args.t_yshift,
             device=device,
         )
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
@@ -555,7 +550,7 @@ def main(args):
     sorted_poses = []
     if args.load:
         args.pretrain = 0
-        flog("Loading checkpoint from {}".format(args.load))
+        logger.info("Loading checkpoint from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -578,7 +573,7 @@ def main(args):
 
     # pretrain decoder with random poses
     global_it = 0
-    flog("Using random poses for {} iterations".format(args.pretrain))
+    logger.info("Using random poses for {} iterations".format(args.pretrain))
     while global_it < args.pretrain:
         for batch in data_iterator:
             global_it += len(batch[0])
@@ -589,7 +584,7 @@ def main(args):
             )
             loss = pretrain(model, lattice, optim, batch, tilt=ps.tilt)
             if global_it % args.log_interval == 0:
-                flog(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
+                logger.info(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
             if global_it > args.pretrain:
                 break
     out_mrc = "{}/pretrain.reconstruct.mrc".format(args.outdir)
@@ -599,7 +594,7 @@ def main(args):
 
     # reset model after pretraining
     if args.reset_optim_after_pretrain:
-        flog(">> Resetting optim after pretrain")
+        logger.info(">> Resetting optim after pretrain")
         optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)
 
     # training loop
@@ -622,17 +617,17 @@ def main(args):
             ps.Lmax = min(Lramp, args.l_end)
 
         if args.reset_model_every and (epoch - 1) % args.reset_model_every == 0:
-            flog(">> Resetting model")
+            logger.info(">> Resetting model")
             model = make_model(args, D)
 
         if args.reset_optim_every and (epoch - 1) % args.reset_optim_every == 0:
-            flog(">> Resetting optim")
+            logger.info(">> Resetting optim")
             optim = torch.optim.Adam(
                 model.parameters(), lr=args.lr, weight_decay=args.wd
             )
 
         if epoch % args.ps_freq != 0:
-            flog("Using previous iteration poses")
+            logger.info("Using previous iteration poses")
         for batch in data_iterator:
             ind = batch[-1]
             ind_np = ind.cpu().numpy()
@@ -674,12 +669,12 @@ def main(args):
             # logging
             loss_accum += loss_item * len(batch[0])
             if batch_it % args.log_interval == 0:
-                log(
+                logger.info(
                     "# [Train Epoch: {}/{}] [{}/{} images] loss={:.4f}".format(
                         epoch + 1, args.num_epochs, batch_it, Nimg, loss_item
                     )
                 )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average loss = {:.4}; Finished in {}".format(
                 epoch + 1, loss_accum / Nimg, dt.now() - t2
             )
@@ -723,7 +718,7 @@ def main(args):
         )
 
         td = dt.now() - t1
-        flog(
+        logger.info(
             "Finished in {} ({} per epoch)".format(
                 td, td / (args.num_epochs - start_epoch)
             )
@@ -733,5 +728,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -133,69 +133,179 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
 
     # Make some plots
     logger.info("Generating plots...")
-    plt.figure(1)
-    g = sns.jointplot(x=pc[:, 0], y=pc[:, 1], alpha=0.1, s=2)
-    g.set_axis_labels("PC1", "PC2")
-    plt.tight_layout()
+
+    def plt_pc_labels(x=0, y=1):
+        plt.xlabel(f"PC{x+1} ({pca.explained_variance_ratio_[x]:.2f})")
+        plt.ylabel(f"PC{y+1} ({pca.explained_variance_ratio_[y]:.2f})")
+
+    def plt_pc_labels_jointplot(g, x=0, y=1):
+        g.ax_joint.set_xlabel(f"PC{x+1} ({pca.explained_variance_ratio_[x]:.2f})")
+        g.ax_joint.set_ylabel(f"PC{y+1} ({pca.explained_variance_ratio_[y]:.2f})")
+
+    def plt_umap_labels():
+        plt.xticks([])
+        plt.yticks([])
+        plt.xlabel("UMAP1")
+        plt.ylabel("UMAP2")
+
+    def plt_umap_labels_jointplot(g):
+        g.ax_joint.set_xlabel("UMAP1")
+        g.ax_joint.set_ylabel("UMAP2")
+
+    # PCA -- Style 1 -- Scatter
+    plt.figure(figsize=(4, 4))
+    plt.scatter(pc[:, 0], pc[:, 1], alpha=0.1, s=1, rasterized=True)
+    plt_pc_labels()
     plt.savefig(f"{outdir}/z_pca.png")
 
-    plt.figure(2)
-    g = sns.jointplot(x=pc[:, 0], y=pc[:, 1], kind="hex")
-    g.set_axis_labels("PC1", "PC2")
-    plt.tight_layout()
+    # PCA -- Style 2 -- Scatter, with marginals
+    g = sns.jointplot(pc[:, 0], pc[:, 1], alpha=0.1, s=1, rasterized=True, height=4)
+    plt_pc_labels_jointplot(g)
+    plt.savefig(f"{outdir}/z_pca_marginals.png")
+
+    # PCA -- Style 3 -- Hexbin
+    g = sns.jointplot(pc[:, 0], pc[:, 1], height=4, kind="hex")
+    plt_pc_labels_jointplot(g)
     plt.savefig(f"{outdir}/z_pca_hexbin.png")
 
     if umap_emb is not None:
-        plt.figure(3)
-        g = sns.jointplot(x=umap_emb[:, 0], y=umap_emb[:, 1], alpha=0.1, s=2)
-        g.set_axis_labels("UMAP1", "UMAP2")
-        plt.tight_layout()
+        # Style 1 -- Scatter
+        plt.figure(figsize=(4, 4))
+        plt.scatter(umap_emb[:, 0], umap_emb[:, 1], alpha=0.1, s=1, rasterized=True)
+        plt_umap_labels()
         plt.savefig(f"{outdir}/umap.png")
 
-        plt.figure(4)
-        g = sns.jointplot(x=umap_emb[:, 0], y=umap_emb[:, 1], kind="hex")
-        g.set_axis_labels("UMAP1", "UMAP2")
-        plt.tight_layout()
+        # Style 2 -- Scatter with marginal distributions
+        g = sns.jointplot(
+            umap_emb[:, 0], umap_emb[:, 1], alpha=0.1, s=1, rasterized=True, height=4
+        )
+        plt_umap_labels_jointplot(g)
+        plt.savefig(f"{outdir}/umap_marginals.png")
+
+        # Style 3 -- Hexbin / heatmap
+        g = sns.jointplot(umap_emb[:, 0], umap_emb[:, 1], kind="hex", height=4)
+        plt_umap_labels_jointplot(g)
         plt.savefig(f"{outdir}/umap_hexbin.png")
 
+    # Plot kmeans sample points
+    colors = analysis._get_chimerax_colors(K)
     analysis.scatter_annotate(
-        pc[:, 0], pc[:, 1], centers_ind=centers_ind, annotate=True
+        pc[:, 0],
+        pc[:, 1],
+        centers_ind=centers_ind,
+        annotate=True,
+        colors=colors,
     )
-    plt.xlabel("PC1")
-    plt.ylabel("PC2")
+    plt_pc_labels()
     plt.savefig(f"{outdir}/kmeans{K}/z_pca.png")
 
     g = analysis.scatter_annotate_hex(
-        pc[:, 0], pc[:, 1], centers_ind=centers_ind, annotate=True
+        pc[:, 0],
+        pc[:, 1],
+        centers_ind=centers_ind,
+        annotate=True,
+        colors=colors,
     )
-    g.set_axis_labels("PC1", "PC2")
-    plt.tight_layout()
+    plt_pc_labels_jointplot(g)
     plt.savefig(f"{outdir}/kmeans{K}/z_pca_hex.png")
 
     if umap_emb is not None:
         analysis.scatter_annotate(
-            umap_emb[:, 0], umap_emb[:, 1], centers_ind=centers_ind, annotate=True
+            umap_emb[:, 0],
+            umap_emb[:, 1],
+            centers_ind=centers_ind,
+            annotate=True,
+            colors=colors,
         )
-        plt.xlabel("UMAP1")
-        plt.ylabel("UMAP2")
+        plt_umap_labels()
         plt.savefig(f"{outdir}/kmeans{K}/umap.png")
 
         g = analysis.scatter_annotate_hex(
-            umap_emb[:, 0], umap_emb[:, 1], centers_ind=centers_ind, annotate=True
+            umap_emb[:, 0],
+            umap_emb[:, 1],
+            centers_ind=centers_ind,
+            annotate=True,
+            colors=colors,
         )
-        g.set_axis_labels("UMAP1", "UMAP2")
-        plt.tight_layout()
+        plt_umap_labels_jointplot(g)
         plt.savefig(f"{outdir}/kmeans{K}/umap_hex.png")
 
+    # Plot PC trajectories
     for i in range(num_pcs):
+        start, end = np.percentile(pc[:, i], (5, 95))
+        z_pc = analysis.get_pc_traj(pca, z.shape[1], 10, i + 1, start, end)
         if umap_emb is not None:
+            # UMAP, colored by PCX
             analysis.scatter_color(
-                umap_emb[:, 0], umap_emb[:, 1], pc[:, i], label=f"PC{i+1}"
+                umap_emb[:, 0],
+                umap_emb[:, 1],
+                pc[:, i],
+                label=f"PC{i+1}",
             )
-            plt.xlabel("UMAP1")
-            plt.ylabel("UMAP2")
-            plt.tight_layout()
+            plt_umap_labels()
             plt.savefig(f"{outdir}/pc{i+1}/umap.png")
+
+            # UMAP, with PC traversal
+            z_pc_on_data, pc_ind = analysis.get_nearest_point(z, z_pc)
+            dists = ((z_pc_on_data - z_pc) ** 2).sum(axis=1) ** 0.5
+            if np.any(dists > 2):
+                logger.warn(
+                    f"Warning: PC{i+1} point locations in UMAP plot may be inaccurate"
+                )
+            plt.figure(figsize=(4, 4))
+            plt.scatter(
+                umap_emb[:, 0], umap_emb[:, 1], alpha=0.05, s=1, rasterized=True
+            )
+            plt.scatter(
+                umap_emb[pc_ind, 0],
+                umap_emb[pc_ind, 1],
+                c="cornflowerblue",
+                edgecolor="black",
+            )
+            plt_umap_labels()
+            plt.savefig(f"{outdir}/pc{i+1}/umap_traversal.png")
+
+            # UMAP, with PC traversal, connected
+            plt.figure(figsize=(4, 4))
+            plt.scatter(
+                umap_emb[:, 0], umap_emb[:, 1], alpha=0.05, s=1, rasterized=True
+            )
+            plt.plot(umap_emb[pc_ind, 0], umap_emb[pc_ind, 1], "--", c="k")
+            plt.scatter(
+                umap_emb[pc_ind, 0],
+                umap_emb[pc_ind, 1],
+                c="cornflowerblue",
+                edgecolor="black",
+            )
+            plt_umap_labels()
+            plt.savefig(f"{outdir}/pc{i+1}/umap_traversal_connected.png")
+
+        # 10 points, from 5th to 95th percentile of PC1 values
+        t = np.linspace(start, end, 10, endpoint=True)
+        plt.figure(figsize=(4, 4))
+        if i > 0 and i == num_pcs - 1:
+            plt.scatter(pc[:, i - 1], pc[:, i], alpha=0.1, s=1, rasterized=True)
+            plt.scatter(np.zeros(10), t, c="cornflowerblue", edgecolor="white")
+            plt_pc_labels(i - 1, i)
+        else:
+            plt.scatter(pc[:, i], pc[:, i + 1], alpha=0.1, s=1, rasterized=True)
+            plt.scatter(t, np.zeros(10), c="cornflowerblue", edgecolor="white")
+            plt_pc_labels(i, i + 1)
+        plt.savefig(f"{outdir}/pc{i+1}/pca_traversal.png")
+
+        if i > 0 and i == num_pcs - 1:
+            g = sns.jointplot(
+                pc[:, i - 1], pc[:, i], alpha=0.1, s=1, rasterized=True, height=4
+            )
+            g.ax_joint.scatter(np.zeros(10), t, c="cornflowerblue", edgecolor="white")
+            plt_pc_labels_jointplot(g, i - 1, i)
+        else:
+            g = sns.jointplot(
+                pc[:, i], pc[:, i + 1], alpha=0.1, s=1, rasterized=True, height=4
+            )
+            g.ax_joint.scatter(t, np.zeros(10), c="cornflowerblue", edgecolor="white")
+            plt_pc_labels_jointplot(g)
+        plt.savefig(f"{outdir}/pc{i+1}/pca_traversal_hex.png")
 
 
 class VolumeGenerator:

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -156,16 +156,19 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
     plt.figure(figsize=(4, 4))
     plt.scatter(pc[:, 0], pc[:, 1], alpha=0.1, s=1, rasterized=True)
     plt_pc_labels()
+    plt.tight_layout()
     plt.savefig(f"{outdir}/z_pca.png")
 
     # PCA -- Style 2 -- Scatter, with marginals
     g = sns.jointplot(pc[:, 0], pc[:, 1], alpha=0.1, s=1, rasterized=True, height=4)
     plt_pc_labels_jointplot(g)
+    plt.tight_layout()
     plt.savefig(f"{outdir}/z_pca_marginals.png")
 
     # PCA -- Style 3 -- Hexbin
     g = sns.jointplot(pc[:, 0], pc[:, 1], height=4, kind="hex")
     plt_pc_labels_jointplot(g)
+    plt.tight_layout()
     plt.savefig(f"{outdir}/z_pca_hexbin.png")
 
     if umap_emb is not None:
@@ -173,6 +176,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
         plt.figure(figsize=(4, 4))
         plt.scatter(umap_emb[:, 0], umap_emb[:, 1], alpha=0.1, s=1, rasterized=True)
         plt_umap_labels()
+        plt.tight_layout()
         plt.savefig(f"{outdir}/umap.png")
 
         # Style 2 -- Scatter with marginal distributions
@@ -180,11 +184,13 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
             umap_emb[:, 0], umap_emb[:, 1], alpha=0.1, s=1, rasterized=True, height=4
         )
         plt_umap_labels_jointplot(g)
+        plt.tight_layout()
         plt.savefig(f"{outdir}/umap_marginals.png")
 
         # Style 3 -- Hexbin / heatmap
         g = sns.jointplot(umap_emb[:, 0], umap_emb[:, 1], kind="hex", height=4)
         plt_umap_labels_jointplot(g)
+        plt.tight_layout()
         plt.savefig(f"{outdir}/umap_hexbin.png")
 
     # Plot kmeans sample points
@@ -197,6 +203,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
         colors=colors,
     )
     plt_pc_labels()
+    plt.tight_layout()
     plt.savefig(f"{outdir}/kmeans{K}/z_pca.png")
 
     g = analysis.scatter_annotate_hex(
@@ -207,6 +214,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
         colors=colors,
     )
     plt_pc_labels_jointplot(g)
+    plt.tight_layout()
     plt.savefig(f"{outdir}/kmeans{K}/z_pca_hex.png")
 
     if umap_emb is not None:
@@ -218,6 +226,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
             colors=colors,
         )
         plt_umap_labels()
+        plt.tight_layout()
         plt.savefig(f"{outdir}/kmeans{K}/umap.png")
 
         g = analysis.scatter_annotate_hex(
@@ -228,6 +237,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
             colors=colors,
         )
         plt_umap_labels_jointplot(g)
+        plt.tight_layout()
         plt.savefig(f"{outdir}/kmeans{K}/umap_hex.png")
 
     # Plot PC trajectories
@@ -243,6 +253,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
                 label=f"PC{i+1}",
             )
             plt_umap_labels()
+            plt.tight_layout()
             plt.savefig(f"{outdir}/pc{i+1}/umap.png")
 
             # UMAP, with PC traversal
@@ -263,6 +274,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
                 edgecolor="black",
             )
             plt_umap_labels()
+            plt.tight_layout()
             plt.savefig(f"{outdir}/pc{i+1}/umap_traversal.png")
 
             # UMAP, with PC traversal, connected
@@ -278,6 +290,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
                 edgecolor="black",
             )
             plt_umap_labels()
+            plt.tight_layout()
             plt.savefig(f"{outdir}/pc{i+1}/umap_traversal_connected.png")
 
         # 10 points, from 5th to 95th percentile of PC1 values
@@ -291,6 +304,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
             plt.scatter(pc[:, i], pc[:, i + 1], alpha=0.1, s=1, rasterized=True)
             plt.scatter(t, np.zeros(10), c="cornflowerblue", edgecolor="white")
             plt_pc_labels(i, i + 1)
+        plt.tight_layout()
         plt.savefig(f"{outdir}/pc{i+1}/pca_traversal.png")
 
         if i > 0 and i == num_pcs - 1:
@@ -305,6 +319,7 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
             )
             g.ax_joint.scatter(t, np.zeros(10), c="cornflowerblue", edgecolor="white")
             plt_pc_labels_jointplot(g)
+        plt.tight_layout()
         plt.savefig(f"{outdir}/pc{i+1}/pca_traversal_hex.png")
 
 

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -391,6 +391,16 @@ def main(args):
         logger.info(f"{out_ipynb} already exists. Skipping")
     logger.info(out_ipynb)
 
+    # copy over template if file doesn't exist
+    out_ipynb = f"{outdir}/cryoDRGN_figures.ipynb"
+    if not os.path.exists(out_ipynb):
+        logger.info("Creating jupyter notebook...")
+        ipynb = f"{cryodrgn._ROOT}/templates/cryoDRGN_figures_template.ipynb"
+        shutil.copyfile(ipynb, out_ipynb)
+    else:
+        logger.info(f"{out_ipynb} already exists. Skipping")
+    logger.info(out_ipynb)
+
     logger.info(f"Finished in {dt.now()-t1}")
 
 

--- a/cryodrgn/commands/downsample.py
+++ b/cryodrgn/commands/downsample.py
@@ -9,7 +9,7 @@ import os
 from multiprocessing import Pool
 import logging
 import numpy as np
-from cryodrgn import dataset, fft, mrc
+from cryodrgn import dataset, fft, mrc, utils
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,12 @@ def add_args(parser):
         default=16,
         help="Maximum number of CPU cores for parallelization (default: %(default)s)",
     )
+    parser.add_argument(
+        "--ind",
+        type=os.path.abspath,
+        metavar="PKL",
+        help="Filter particle stack by these indices",
+    )
     return parser
 
 
@@ -74,6 +80,12 @@ def main(args):
 
     lazy = not args.is_vol
     old = dataset.load_particles(args.mrcs, lazy=lazy, datadir=args.datadir)
+
+    if args.ind is not None:
+        assert not args.is_vol
+        logger.info(f"Filtering image dataset with {args.ind}")
+        ind = utils.load_pkl(args.ind).astype(int)
+        old = [old[i] for i in ind] if lazy else old[ind]
 
     if lazy:
         oldD = old[0].get().shape[0]

--- a/cryodrgn/commands/eval_images.py
+++ b/cryodrgn/commands/eval_images.py
@@ -197,6 +197,9 @@ def eval_batch(
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
 
     # make output directories
@@ -364,6 +367,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_images.py
+++ b/cryodrgn/commands/eval_images.py
@@ -6,18 +6,16 @@ import os
 import pickle
 import pprint
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-
 from cryodrgn import config, ctf, dataset, utils
 from cryodrgn.commands.train_vae import loss_function, preprocess_input, run_batch
 from cryodrgn.models import HetOnlyVAE
 from cryodrgn.pose import PoseTracker
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -210,13 +208,13 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    log("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        log("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
-    log(args)
+    logger.info(args)
     cfg = config.overwrite_config(args.config, args)
-    log("Loaded configuration:")
+    logger.info("Loaded configuration:")
     pprint.pprint(cfg)
 
     zdim = cfg["model_args"]["zdim"]
@@ -224,7 +222,7 @@ def main(args):
 
     # load the particles
     if args.ind is not None:
-        log("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
@@ -287,7 +285,7 @@ def main(args):
             raise NotImplementedError(
                 "Not implemented with real-space encoder. Use phase-flipped images instead"
             )
-        log("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -333,12 +331,12 @@ def main(args):
         loss_accum += loss * B
 
         if batch_it % args.log_interval == 0:
-            log(
+            logger.info(
                 "# [{}/{} images] gen loss={:.4f}, kld={:.4f}, beta={:.4f}, loss={:.4f}".format(
                     batch_it, Nimg, gen_loss, kld, beta, loss
                 )
             )
-    log(
+    logger.info(
         "# =====> Average gen loss = {:.6}, KLD = {:.6f}, total loss = {:.6f}".format(
             gen_loss_accum / Nimg, kld_accum / Nimg, loss_accum / Nimg
         )
@@ -360,11 +358,12 @@ def main(args):
             f,
         )
 
-    log("Finished in {}".format(dt.now() - t1))
+    logger.info("Finished in {}".format(dt.now() - t1))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -22,6 +22,7 @@ def add_args(parser):
     parser.add_argument(
         "-o", type=os.path.abspath, required=True, help="Output .mrc or directory"
     )
+    parser.add_argument("--device", type=int, help="Optionally specify CUDA device")
     parser.add_argument(
         "--prefix",
         default="vol_",
@@ -143,11 +144,14 @@ def main(args):
     t1 = dt.now()
 
     # set the device
-    use_cuda = torch.cuda.is_available()
-    device = torch.device("cuda" if use_cuda else "cpu")
-    logger.info("Use cuda {}".format(use_cuda))
-    if not use_cuda:
-        logger.warning("WARNING: No GPUs detected")
+    if args.device is not None:
+        device = torch.device(f"cuda:{args.device}")
+    else:
+        use_cuda = torch.cuda.is_available()
+        device = torch.device("cuda" if use_cuda else "cpu")
+        logger.info("Use cuda {}".format(use_cuda))
+        if not use_cuda:
+            logger.warning("WARNING: No GPUs detected")
 
     logger.info(args)
     cfg = config.overwrite_config(args.config, args)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -28,9 +28,6 @@ def add_args(parser):
         help="Prefix when writing out multiple .mrc files (default: %(default)s)",
     )
     parser.add_argument(
-        "--device", type=int, default=None, help="Optionally specify CUDA device"
-    )
-    parser.add_argument(
         "-v", "--verbose", action="store_true", help="Increase verbosity"
     )
 
@@ -146,14 +143,11 @@ def main(args):
     t1 = dt.now()
 
     # set the device
-    if args.device is not None:
-        use_cuda = torch.cuda.is_available()
-        device = torch.device(f"cuda:{args.device}" if use_cuda else "cpu")
-        logger.info("Use cuda device {}".format(args.device))
-        if not use_cuda:
-            logger.warning("WARNING: No GPUs used")
-    else:
-        device = "cpu"
+    use_cuda = torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu")
+    logger.info("Use cuda {}".format(use_cuda))
+    if not use_cuda:
+        logger.warning("WARNING: No GPUs detected")
 
     logger.info(args)
     cfg = config.overwrite_config(args.config, args)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -8,7 +8,7 @@ from datetime import datetime as dt
 import logging
 import numpy as np
 import torch
-from cryodrgn import config, mrc, utils
+from cryodrgn import config, mrc
 from cryodrgn.models import HetOnlyVAE
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,6 @@ def main(args):
 
     # Multiple z
     if args.z_start or args.zfile:
-
         # Get z values
         if args.z_start:
             args.z_start = np.array(args.z_start)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -5,15 +5,13 @@ import argparse
 import os
 import pprint
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
-
 from cryodrgn import config, mrc, utils
 from cryodrgn.models import HetOnlyVAE
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -148,15 +146,15 @@ def main(args):
     if args.device is not None:
         use_cuda = torch.cuda.is_available()
         device = torch.device(f"cuda:{args.device}" if use_cuda else "cpu")
-        log("Use cuda device {}".format(args.device))
+        logger.info("Use cuda device {}".format(args.device))
         if not use_cuda:
-            log("WARNING: No GPUs used")
+            logger.warning("WARNING: No GPUs used")
     else:
         device = "cpu"
 
-    log(args)
+    logger.info(args)
     cfg = config.overwrite_config(args.config, args)
-    log("Loaded configuration:")
+    logger.info("Loaded configuration:")
     pprint.pprint(cfg)
 
     D = cfg["lattice_args"]["D"]  # image size + 1
@@ -188,9 +186,9 @@ def main(args):
         if not os.path.exists(args.o):
             os.makedirs(args.o)
 
-        log(f"Generating {len(z)} volumes")
+        logger.info(f"Generating {len(z)} volumes")
         for i, zz in enumerate(z, start=args.vol_start_index):
-            log(zz)
+            logger.info(zz)
             if args.downsample:
                 extent = lattice.extent * (args.downsample / (D - 1))
                 decoder = model.decoder
@@ -215,7 +213,7 @@ def main(args):
     # Single z
     else:
         z = np.array(args.z)
-        log(z)
+        logger.info(z)
         if args.downsample:
             extent = lattice.extent * (args.downsample / (D - 1))
             vol = model.decoder.eval_volume(
@@ -236,11 +234,12 @@ def main(args):
         mrc.write(args.o, vol.astype(np.float32), Apix=args.Apix)
 
     td = dt.now() - t1
-    log("Finished in {}".format(td))
+    logger.info("Finished in {}".format(td))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -139,6 +139,9 @@ def check_inputs(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     check_inputs(args)
     t1 = dt.now()
 
@@ -240,6 +243,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/parse_ctf_csparc.py
+++ b/cryodrgn/commands/parse_ctf_csparc.py
@@ -3,12 +3,11 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
+from cryodrgn import ctf
 
-from cryodrgn import ctf, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -32,7 +31,7 @@ def main(args):
 
     metadata = np.load(args.cs)
     N = len(metadata)
-    log("{} particles".format(N))
+    logger.info("{} particles".format(N))
 
     # sometimes blob/shape, blob/psize_A are missing from the .cs file
     try:
@@ -62,7 +61,7 @@ def main(args):
             ctf_params[:, i + 2] *= 180 / np.pi
 
     ctf.print_ctf_params(ctf_params[0])
-    log("Saving {}".format(args.o))
+    logger.info("Saving {}".format(args.o))
     with open(args.o, "wb") as f:
         pickle.dump(ctf_params.astype(np.float32), f)
     if args.png:
@@ -70,7 +69,7 @@ def main(args):
 
         ctf.plot_ctf(int(ctf_params[0, 0]), ctf_params[0, 1], ctf_params[0, 2:])
         plt.savefig(args.png)
-        log(args.png)
+        logger.info(args.png)
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands/parse_ctf_star.py
+++ b/cryodrgn/commands/parse_ctf_star.py
@@ -5,7 +5,7 @@ import os
 import pickle
 import logging
 import numpy as np
-from cryodrgn import ctf, starfile, utils
+from cryodrgn import ctf, starfile
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/commands/parse_pose_csparc.py
+++ b/cryodrgn/commands/parse_pose_csparc.py
@@ -3,13 +3,12 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
 import torch
+from cryodrgn import lie_tools
 
-from cryodrgn import lie_tools, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -50,28 +49,28 @@ def main(args):
         TKEY = "alignments3D/shift"
 
     # parse rotations
-    log(f"Extracting rotations from {RKEY}")
+    logger.info(f"Extracting rotations from {RKEY}")
     rot = np.array([x[RKEY] for x in data])
     rot = torch.tensor(rot)
     rot = lie_tools.expmap(rot)
     rot = rot.numpy()
-    log("Transposing rotation matrix")
+    logger.info("Transposing rotation matrix")
     rot = np.array([x.T for x in rot])
-    log(rot.shape)
+    logger.info(rot.shape)
 
     # parse translations
-    log(f"Extracting translations from {TKEY}")
+    logger.info(f"Extracting translations from {TKEY}")
     trans = np.array([x[TKEY] for x in data])
     if args.hetrefine:
-        log("Scaling shifts by 2x")
+        logger.info("Scaling shifts by 2x")
         trans *= 2
-    log(trans.shape)
+    logger.info(trans.shape)
 
     # convert translations from pixels to fraction
     trans /= args.D
 
     # write output
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     with open(args.o, "wb") as f:
         pickle.dump((rot, trans), f)
 

--- a/cryodrgn/commands/parse_pose_star.py
+++ b/cryodrgn/commands/parse_pose_star.py
@@ -3,12 +3,11 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
-
 from cryodrgn import starfile, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -44,19 +43,19 @@ def main(args):
     assert args.D is not None, "Must provide image size with -D"
 
     N = len(s.df)
-    log(f"{N} particles")
+    logger.info(f"{N} particles")
 
     # parse rotations
     euler = np.zeros((N, 3))
     euler[:, 0] = s.df["_rlnAngleRot"]
     euler[:, 1] = s.df["_rlnAngleTilt"]
     euler[:, 2] = s.df["_rlnAnglePsi"]
-    log("Euler angles (Rot, Tilt, Psi):")
-    log(euler[0])
-    log("Converting to rotation matrix:")
+    logger.info("Euler angles (Rot, Tilt, Psi):")
+    logger.info(euler[0])
+    logger.info("Converting to rotation matrix:")
     rot = np.asarray([utils.R_from_relion(*x) for x in euler])
 
-    log(rot[0])
+    logger.info(rot[0])
 
     # parse translations
     trans = np.zeros((N, 2))
@@ -73,18 +72,18 @@ def main(args):
         trans[:, 1] = s.df["_rlnOriginYAngst"]
         trans /= args.Apix
     else:
-        log(
+        logger.warning(
             "Warning: Neither _rlnOriginX/Y nor _rlnOriginX/YAngst found. Defaulting to 0s."
         )
 
-    log("Translations (pixels):")
-    log(trans[0])
+    logger.info("Translations (pixels):")
+    logger.info(trans[0])
 
     # convert translations from pixels to fraction
     trans /= args.D
 
     # write output
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     with open(args.o, "wb") as f:
         pickle.dump((rot, trans), f)
 

--- a/cryodrgn/commands/preprocess.py
+++ b/cryodrgn/commands/preprocess.py
@@ -61,7 +61,7 @@ def add_args(parser):
         help="Turn off real space windowing of dataset",
     )
 
-    group = parser.add_argument_group("Extra arguments for volume generation")
+    group = parser.add_argument_group("Extra arguments for image downsampling")
     group.add_argument(
         "-b",
         type=int,

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -10,7 +10,6 @@ import logging
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.nn.parallel import DataParallel
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
@@ -20,8 +19,7 @@ except ImportError:
     pass
 
 import cryodrgn
-import cryodrgn.types as types
-from cryodrgn import ctf, dataset, models, mrc, utils
+from cryodrgn import ctf, dataset, models, mrc
 from cryodrgn.lattice import Lattice
 from cryodrgn.pose import PoseTracker
 from cryodrgn.models import DataParallelDecoder, Decoder

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -350,6 +350,9 @@ def get_latest(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -563,6 +566,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import sys
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
 import torch.nn as nn
@@ -26,8 +26,7 @@ from cryodrgn.lattice import Lattice
 from cryodrgn.pose import PoseTracker
 from cryodrgn.models import DataParallelDecoder, Decoder
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -335,18 +334,18 @@ def save_config(args, dataset, lattice, model, out_config):
         pickle.dump(meta, f)
 
 
-def get_latest(args, flog):
+def get_latest(args):
     # assumes args.num_epochs > latest checkpoint
-    flog("Detecting latest checkpoint...")
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     if args.do_pose_sgd:
         i = args.load.split(".")[-2]
         args.poses = f"{args.outdir}/pose.{i}.pkl"
         assert os.path.exists(args.poses)
-        flog(f"Loading {args.poses}")
+        logger.info(f"Loading {args.poses}")
     return args
 
 
@@ -354,15 +353,13 @@ def main(args):
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -371,13 +368,13 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        flog("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # load the particles
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
@@ -390,7 +387,6 @@ def main(args):
             window=args.window,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
     else:
         data = dataset.MRCData(
@@ -401,7 +397,6 @@ def main(args):
             window=args.window,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
     D = data.D
     Nimg = data.N
@@ -423,8 +418,8 @@ def main(args):
         feat_sigma=args.feat_sigma,
     )
     model.to(device)
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
@@ -435,7 +430,7 @@ def main(args):
 
     # load weights
     if args.load:
-        flog("Loading model weights from {}".format(args.load))
+        logger.info("Loading model weights from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -461,7 +456,7 @@ def main(args):
 
     # load CTF
     if args.ctf is not None:
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -493,12 +488,12 @@ def main(args):
 
     # parallelize
     if args.multigpu and torch.cuda.device_count() > 1:
-        flog(f"Using {torch.cuda.device_count()} GPUs!")
+        logger.info(f"Using {torch.cuda.device_count()} GPUs!")
         args.batch_size *= torch.cuda.device_count()
-        flog(f"Increasing batch size to {args.batch_size}")
+        logger.info(f"Increasing batch size to {args.batch_size}")
         model = DataParallelDecoder(model)
     elif args.multigpu:
-        flog(
+        logger.info(
             f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
         )
 
@@ -531,12 +526,12 @@ def main(args):
                 pose_optimizer.step()
             loss_accum += loss_item * len(ind)
             if batch_it % args.log_interval == 0:
-                flog(
+                logger.info(
                     "# [Train Epoch: {}/{}] [{}/{} images] loss={:.6f}".format(
                         epoch + 1, args.num_epochs, batch_it, Nimg, loss_item
                     )
                 )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average loss = {:.6}; Finished in {}".format(
                 epoch + 1, loss_accum / Nimg, dt.now() - t2
             )
@@ -560,7 +555,7 @@ def main(args):
         posetracker.save(out_pose)
 
     td = dt.now() - t1
-    flog(
+    logger.info(
         "Finished in {} ({} per epoch)".format(td, td / (args.num_epochs - start_epoch))
     )
 
@@ -568,5 +563,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -554,6 +554,9 @@ def get_latest(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -919,6 +922,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import pickle
 import sys
+import logging
 from datetime import datetime as dt
 import numpy as np
 import torch
@@ -25,8 +26,7 @@ from cryodrgn.lattice import Lattice
 from cryodrgn.models import HetOnlyVAE, unparallelize
 from cryodrgn.pose import PoseTracker
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -538,18 +538,18 @@ def save_config(args, dataset, lattice, model, out_config):
         pickle.dump(meta, f)
 
 
-def get_latest(args, flog):
+def get_latest(args):
     # assumes args.num_epochs > latest checkpoint
-    flog("Detecting latest checkpoint...")
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     if args.do_pose_sgd:
         i = args.load.split(".")[-2]
         args.poses = f"{args.outdir}/pose.{i}.pkl"
         assert os.path.exists(args.poses)
-        flog(f"Loading {args.poses}")
+        logger.info(f"Loading {args.poses}")
     return args
 
 
@@ -557,15 +557,13 @@ def main(args):
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -574,9 +572,9 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        log("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # set beta schedule
     if args.beta is None:
@@ -591,13 +589,13 @@ def main(args):
 
     # load index filter
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
 
     # load dataset
-    flog(f"Loading dataset from {args.particles}")
+    logger.info(f"Loading dataset from {args.particles}")
     if args.tilt is None:
         tilt = None
         args.use_real = args.encode_mode == "conv"  # Must be False
@@ -612,14 +610,13 @@ def main(args):
                 window=args.window,
                 datadir=args.datadir,
                 window_r=args.window_r,
-                flog=flog,
             )
         elif args.preprocessed:
-            flog(
+            logger.info(
                 "Using preprocessed inputs. Ignoring any --window/--invert-data options"
             )
             data = dataset.PreprocessedMRCData(
-                args.particles, norm=args.norm, ind=ind, flog=flog, lazy=args.lazy
+                args.particles, norm=args.norm, ind=ind, lazy=args.lazy
             )
         else:
             data = dataset.MRCData(
@@ -632,7 +629,6 @@ def main(args):
                 datadir=args.datadir,
                 max_threads=args.max_threads,
                 window_r=args.window_r,
-                flog=flog,
             )
 
     # Tilt series data -- lots of unsupported features
@@ -652,7 +648,6 @@ def main(args):
             keepreal=args.use_real,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = torch.tensor(utils.xrot(args.tilt_deg).astype(np.float32), device=device)
     Nimg = data.N
@@ -683,7 +678,7 @@ def main(args):
             raise NotImplementedError(
                 "Not implemented with real-space encoder. Use phase-flipped images instead"
             )
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -725,18 +720,18 @@ def main(args):
         feat_sigma=args.feat_sigma,
     )
     model.to(device)
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
     )
-    flog(
+    logger.info(
         "{} parameters in encoder".format(
             sum(p.numel() for p in model.encoder.parameters() if p.requires_grad)
         )
     )
-    flog(
+    logger.info(
         "{} parameters in decoder".format(
             sum(p.numel() for p in model.decoder.parameters() if p.requires_grad)
         )
@@ -763,11 +758,11 @@ def main(args):
         ), "Encoder hidden layer dimension must be divisible by 8 for AMP training"
         # Also check zdim, enc_mask dim? Add them as warnings for now.
         if args.zdim % 8 != 0:
-            log(
+            logger.warning(
                 "Warning: z dimension is not a multiple of 8 -- AMP training speedup is not optimized"
             )
         if in_dim % 8 != 0:
-            log(
+            logger.warning(
                 "Warning: Masked input image dimension is not a mutiple of 8 -- AMP training speedup is not optimized"
             )
         try:  # Mixed precision with apex.amp
@@ -778,7 +773,7 @@ def main(args):
 
     # restart from checkpoint
     if args.load:
-        flog("Loading checkpoint from {}".format(args.load))
+        logger.info("Loading checkpoint from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -790,15 +785,15 @@ def main(args):
     # parallelize
     num_workers_per_gpu = args.num_workers_per_gpu
     if args.multigpu and torch.cuda.device_count() > 1:
-        log(f"Using {torch.cuda.device_count()} GPUs!")
+        logger.info(f"Using {torch.cuda.device_count()} GPUs!")
         args.batch_size *= torch.cuda.device_count()
         cpu_count = os.cpu_count() or 1
         if num_workers_per_gpu * torch.cuda.device_count() > cpu_count:
             num_workers_per_gpu = max(1, cpu_count // torch.cuda.device_count())
-        log(f"Increasing batch size to {args.batch_size}")
+        logger.info(f"Increasing batch size to {args.batch_size}")
         model = DataParallel(model)
     elif args.multigpu:
-        log(
+        logger.warning(
             f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
         )
 
@@ -857,13 +852,13 @@ def main(args):
             loss_accum += loss * B
 
             if batch_it % args.log_interval == 0:
-                log(
+                logger.info(
                     "# [Train Epoch: {}/{}] [{}/{} images] gen loss={:.6f}, kld={:.6f}, beta={:.6f}, "
                     "loss={:.6f}".format(
                         epoch + 1, num_epochs, batch_it, Nimg, gen_loss, kld, beta, loss
                     )
                 )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average gen loss = {:.6}, KLD = {:.6f}, total loss = {:.6f}; Finished in {}".format(
                 epoch + 1,
                 gen_loss_accum / Nimg,
@@ -916,11 +911,14 @@ def main(args):
         out_pose = "{}/pose.pkl".format(args.outdir)
         posetracker.save(out_pose)
     td = dt.now() - t1
-    flog("Finished in {} ({} per epoch)".format(td, td / (num_epochs - start_epoch)))
+    logger.info(
+        "Finished in {} ({} per epoch)".format(td, td / (num_epochs - start_epoch))
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/view_config.py
+++ b/cryodrgn/commands/view_config.py
@@ -6,10 +6,9 @@ import argparse
 import os
 import pickle
 from pprint import pprint
+import logging
 
-from cryodrgn import utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -24,13 +23,13 @@ def main(args):
     cfg = pickle.load(f)
     try:
         meta = pickle.load(f)
-        log(f'Version: {meta["version"]}')
-        log(f'Creation time: {meta["time"]}')
-        log("Command:")
+        logger.info(f'Version: {meta["version"]}')
+        logger.info(f'Creation time: {meta["time"]}')
+        logger.info("Command:")
         print(" ".join(meta["cmd"]))
     except:  # noqa: E722
         pass
-    log("Config:")
+    logger.info("Config:")
     pprint(cfg)
 
 

--- a/cryodrgn/commands_utils/add_psize.py
+++ b/cryodrgn/commands_utils/add_psize.py
@@ -1,10 +1,11 @@
 """Add pixel size to header of .mrc file"""
 
 import argparse
+import logging
 import numpy as np
-from cryodrgn import mrc, utils
+from cryodrgn import mrc
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -23,7 +24,7 @@ def main(args):
     assert isinstance(x, np.ndarray)
     h.update_apix(args.Apix)
     mrc.write(args.o, x, header=h)
-    log(f"Wrote {args.o}")
+    logger.info(f"Wrote {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/concat_pkls.py
+++ b/cryodrgn/commands_utils/concat_pkls.py
@@ -2,10 +2,10 @@
 
 import argparse
 import pickle
-
+import logging
 import numpy as np
 
-log = print
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -21,14 +21,14 @@ def main(args):
         t = [xx[1] for xx in x]
         r2 = np.concatenate(r)
         t2 = np.concatenate(t)
-        log(r2.shape)
-        log(t2.shape)
+        logger.info(r2.shape)
+        logger.info(t2.shape)
         x2 = (r2, t2)
     else:
         for i in x:
-            log(i.shape)
+            logger.info(i.shape)
         x2 = np.concatenate(x)
-        log(x2.shape)
+        logger.info(x2.shape)
     pickle.dump(x2, open(args.o, "wb"))
 
 

--- a/cryodrgn/commands_utils/filter_mrcs.py
+++ b/cryodrgn/commands_utils/filter_mrcs.py
@@ -1,12 +1,11 @@
 """Filter a particle stack"""
 
 import argparse
-
+import logging
 import numpy as np
-
 from cryodrgn import dataset, mrc, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -18,10 +17,10 @@ def add_args(parser):
 
 def main(args):
     x = dataset.load_particles(args.input, lazy=True)
-    log(f"Loaded {len(x)} particles")
+    logger.info(f"Loaded {len(x)} particles")
     ind = utils.load_pkl(args.ind)
     x = np.array([x[i].get() for i in ind])
-    log(f"New dimensions: {x.shape}")
+    logger.info(f"New dimensions: {x.shape}")
     mrc.write(args.o, x)
 
 

--- a/cryodrgn/commands_utils/filter_pkl.py
+++ b/cryodrgn/commands_utils/filter_pkl.py
@@ -3,10 +3,10 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
 
-log = print
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -34,18 +34,18 @@ def main(args):
 
     # pose.pkl contains a tuple of rotations and translations
     if type(x) == tuple:
-        log("Detected pose.pkl")
-        log(f"Old shape: {[xx.shape for xx in x]}")
+        logger.info("Detected pose.pkl")
+        logger.info(f"Old shape: {[xx.shape for xx in x]}")
         x = (xx[ind] for xx in x)
         x = tuple(x)
-        log(f"New shape: {[xx.shape for xx in x]}")
+        logger.info(f"New shape: {[xx.shape for xx in x]}")
 
     # all other cryodrgn pkls
     else:
-        log(f"Old shape: {x.shape}")
+        logger.info(f"Old shape: {x.shape}")
         x = x[ind]
-        log(f"New shape: {x.shape}")
-    log(f"Saving {args.o}")
+        logger.info(f"New shape: {x.shape}")
+    logger.info(f"Saving {args.o}")
     pickle.dump(x, open(args.o, "wb"))
 
 

--- a/cryodrgn/commands_utils/filter_star.py
+++ b/cryodrgn/commands_utils/filter_star.py
@@ -5,11 +5,10 @@ Filter a .star file
 import argparse
 import os
 import warnings
-
-from cryodrgn import utils
+import logging
 from cryodrgn.commands_utils import write_star
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -22,7 +21,7 @@ def add_args(parser):
 def main(args):
     warning_msg = "cryodrgn_utils filter_star is deprecated. Please use cryodrgn_utils write_star instead."
     warnings.warn(warning_msg, DeprecationWarning)
-    log(f"WARNING: {warning_msg}")
+    logger.warning(f"WARNING: {warning_msg}")
 
     args = write_star.add_args(argparse.ArgumentParser()).parse_args(
         [

--- a/cryodrgn/commands_utils/flip_hand.py
+++ b/cryodrgn/commands_utils/flip_hand.py
@@ -1,10 +1,11 @@
 """Flip handedness of an .mrc file"""
 
 import argparse
+import logging
 import numpy as np
-from cryodrgn import mrc, utils
+from cryodrgn import mrc
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -20,7 +21,7 @@ def main(args):
     assert isinstance(x, np.ndarray)
     x = x[::-1]
     mrc.write(args.o, x, header=h)
-    log(f"Wrote {args.o}")
+    logger.info(f"Wrote {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/invert_contrast.py
+++ b/cryodrgn/commands_utils/invert_contrast.py
@@ -1,10 +1,11 @@
 """Invert the contrast of an .mrc file"""
 
 import argparse
+import logging
 import numpy as np
-from cryodrgn import mrc, utils
+from cryodrgn import mrc
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -20,7 +21,7 @@ def main(args):
     assert isinstance(x, np.ndarray)
     x *= -1
     mrc.write(args.o, x, header=h)
-    log(f"Wrote {args.o}")
+    logger.info(f"Wrote {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/phase_flip.py
+++ b/cryodrgn/commands_utils/phase_flip.py
@@ -2,12 +2,11 @@
 
 import argparse
 import os
-
+import logging
 import numpy as np
+from cryodrgn import ctf, dataset, fft, mrc
 
-from cryodrgn import ctf, dataset, fft, mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -36,7 +35,7 @@ def main(args):
     imgs_flip = np.empty((len(imgs), D, D), dtype=np.float32)
     for i in range(len(imgs)):
         if i % 1000 == 0:
-            log(f"Processing image {i}")
+            logger.info(f"Processing image {i}")
         c = ctf.compute_ctf_np(freqs / ctf_params[i, 0], *ctf_params[i, 1:])
         c = c.reshape((D, D))
         ff = fft.fft2_center(imgs[i].get())
@@ -44,7 +43,7 @@ def main(args):
         img = fft.ifftn_center(ff)
         imgs_flip[i] = img.astype(np.float32)
 
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     mrc.write(args.o, imgs_flip)
 
 

--- a/cryodrgn/commands_utils/select_clusters.py
+++ b/cryodrgn/commands_utils/select_clusters.py
@@ -2,10 +2,10 @@
 
 import argparse
 import os
-
+import logging
 from cryodrgn import analysis, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -27,19 +27,19 @@ def add_args(parser):
 
 def main(args):
     labels = utils.load_pkl(args.labels)
-    log(f"{len(labels)} particles")
-    log(f"Selecting clusters {args.sel}")
+    logger.info(f"{len(labels)} particles")
+    logger.info(f"Selecting clusters {args.sel}")
     ind = analysis.get_ind_for_cluster(labels, args.sel)
-    log(f"Selected {len(ind)} particles")
-    log(ind)
+    logger.info(f"Selected {len(ind)} particles")
+    logger.info(ind)
     if args.parent_ind is not None:
-        log("Converting to original indices")
+        logger.info("Converting to original indices")
         parent_ind = utils.load_pkl(args.parent_ind)
         assert args.N_orig
         ind = analysis.convert_original_indices(ind, args.N_orig, parent_ind)
-        log(ind)
+        logger.info(ind)
     utils.save_pkl(ind, args.o)
-    log(f"Saved {args.o}")
+    logger.info(f"Saved {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/translate_mrcs.py
+++ b/cryodrgn/commands_utils/translate_mrcs.py
@@ -2,13 +2,12 @@
 
 import argparse
 import os
-
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
-
 from cryodrgn import dataset, fft, mrc, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -43,7 +42,7 @@ def main(args):
     # load particles
     particles = dataset.load_particles(args.mrcs, datadir=args.datadir)
     assert isinstance(particles, np.ndarray)
-    log(particles.shape)
+    logger.info(particles.shape)
     Nimg, D, D = particles.shape
 
     trans = utils.load_pkl(args.trans)
@@ -62,14 +61,14 @@ def main(args):
     imgs = np.empty((Nimg, D, D), dtype=np.float32)
     for ii in range(Nimg):
         if ii % 1000 == 0:
-            log(f"Processing image {ii}")
+            logger.info(f"Processing image {ii}")
         ff = fft.fft2_center(particles[ii])
         tfilt = np.dot(TCOORD, trans[ii]) * -2 * np.pi
         tfilt = np.cos(tfilt) + np.sin(tfilt) * 1j
         ff *= tfilt
         imgs[ii] = fft.ifftn_center(ff).astype(np.float32)
 
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     mrc.write(args.o, imgs)
 
     if args.out_png:

--- a/cryodrgn/commands_utils/view_header.py
+++ b/cryodrgn/commands_utils/view_header.py
@@ -2,10 +2,10 @@
 
 import argparse
 from pprint import pprint
+import logging
+from cryodrgn import mrc
 
-from cryodrgn import mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -15,7 +15,7 @@ def add_args(parser):
 
 def main(args):
     if not (args.input.endswith(".mrc") or args.input.endswith(".mrcs")):
-        log(f"Warning: {args.input} does not appear to be a .mrc(s) file")
+        logger.warning(f"Warning: {args.input} does not appear to be a .mrc(s) file")
     header = mrc.parse_header(args.input)
     pprint(header.fields)
     pprint(header.extended_header)

--- a/cryodrgn/commands_utils/view_mrcs.py
+++ b/cryodrgn/commands_utils/view_mrcs.py
@@ -1,12 +1,11 @@
 """View the first 9 images in a particle stack"""
 
 import argparse
-
+import logging
 import matplotlib.pyplot as plt
+from cryodrgn import analysis, mrc
 
-from cryodrgn import analysis, mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -18,14 +17,14 @@ def add_args(parser):
 
 def main(args):
     stack, _ = mrc.parse_mrc(args.input, lazy=True)
-    log("{} {}x{} images".format(len(stack), *stack[0].get().shape))
+    logger.info("{} {}x{} images".format(len(stack), *stack[0].get().shape))
     stack = [stack[x].get() for x in range(9)]
     if args.invert:
         stack = [-1 * x for x in stack]
     analysis.plot_projections(stack)
     if args.o:
         plt.savefig(args.o)
-        log(f"Wrote {args.o}")
+        logger.info(f"Wrote {args.o}")
     else:
         plt.show()
 

--- a/cryodrgn/commands_utils/write_cs.py
+++ b/cryodrgn/commands_utils/write_cs.py
@@ -5,9 +5,10 @@ Create a CryoSparc .cs file from a particle stack and ctf parameters, or an inpu
 import argparse
 import os
 import numpy as np
+import logging
 from cryodrgn import dataset, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -59,11 +60,11 @@ def main(args):
             assert len(particles) == len(
                 poses[0]
             ), f"{len(particles)} != {len(poses)}, Number of particles != number of poses"
-    log(f"{len(particles)} particles in {args.particles}")
+    logger.info(f"{len(particles)} particles in {args.particles}")
 
     if args.ind:
         ind = utils.load_pkl(args.ind)
-        log(f"Filtering to {len(ind)} particles")
+        logger.info(f"Filtering to {len(ind)} particles")
         particles = np.array(particles)[ind]
 
     if input_ext == ".cs":

--- a/cryodrgn/commands_utils/write_star.py
+++ b/cryodrgn/commands_utils/write_star.py
@@ -6,10 +6,12 @@ import argparse
 import os
 import numpy as np
 import pandas as pd
+import logging
 from cryodrgn import dataset, mrc, utils
 from cryodrgn.starfile import Starfile
 
-log = utils.log
+logger = logging.getLogger(__name__)
+
 
 CTF_HEADERS = [
     "_rlnDefocusU",
@@ -99,7 +101,7 @@ def main(args):
             assert len(particles) == len(
                 poses[0]
             ), f"{len(particles)} != {len(poses)}, Number of particles != number of poses"
-    log(f"{len(particles)} particles in {args.particles}")
+    logger.info(f"{len(particles)} particles in {args.particles}")
 
     if input_ext == ".star":
         particle_ind = np.arange(len(particles))
@@ -113,7 +115,7 @@ def main(args):
 
     if args.ind:
         ind = utils.load_pkl(args.ind)
-        log(f"Filtering to {len(ind)} particles")
+        logger.info(f"Filtering to {len(ind)} particles")
         particles = [particles[ii] for ii in ind]
         if ctf is not None:
             ctf = ctf[ind]

--- a/cryodrgn/ctf.py
+++ b/cryodrgn/ctf.py
@@ -2,10 +2,10 @@ from typing import Union, Optional
 import numpy as np
 import seaborn as sns
 import torch
-
+import logging
 from cryodrgn import utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def compute_ctf(
@@ -107,15 +107,15 @@ def compute_ctf_np(
 
 def print_ctf_params(params: np.ndarray) -> None:
     assert len(params) == 9
-    log("Image size (pix)  : {}".format(int(params[0])))
-    log("A/pix             : {}".format(params[1]))
-    log("DefocusU (A)      : {}".format(params[2]))
-    log("DefocusV (A)      : {}".format(params[3]))
-    log("Dfang (deg)       : {}".format(params[4]))
-    log("voltage (kV)      : {}".format(params[5]))
-    log("cs (mm)           : {}".format(params[6]))
-    log("w                 : {}".format(params[7]))
-    log("Phase shift (deg) : {}".format(params[8]))
+    logger.info("Image size (pix)  : {}".format(int(params[0])))
+    logger.info("A/pix             : {}".format(params[1]))
+    logger.info("DefocusU (A)      : {}".format(params[2]))
+    logger.info("DefocusV (A)      : {}".format(params[3]))
+    logger.info("Dfang (deg)       : {}".format(params[4]))
+    logger.info("voltage (kV)      : {}".format(params[5]))
+    logger.info("cs (mm)           : {}".format(params[6]))
+    logger.info("w                 : {}".format(params[7]))
+    logger.info("Phase shift (deg) : {}".format(params[8]))
 
 
 def plot_ctf(D: int, Apix: float, ctf_params: np.ndarray) -> None:

--- a/cryodrgn/ctf.py
+++ b/cryodrgn/ctf.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Optional
 import numpy as np
 import seaborn as sns
 import torch

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -9,7 +9,7 @@ except ImportError:
 
 import multiprocessing as mp
 import os
-from multiprocessing import Pool
+import multiprocessing
 import logging
 from torch.utils import data
 
@@ -186,7 +186,8 @@ class MRCData(data.Dataset):
         max_threads = min(max_threads, mp.cpu_count())
         if max_threads > 1:
             logger.info(f"Spawning {max_threads} processes")
-            with Pool(max_threads) as p:
+            context = multiprocessing.get_context("spawn")
+            with context.Pool(max_threads) as p:
                 particles = pp.asarray(
                     p.map(fft.ht2_center, particles), dtype=pp.float32
                 )

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -13,7 +13,7 @@ from multiprocessing import Pool
 import logging
 from torch.utils import data
 
-from cryodrgn import fft, mrc, starfile, utils
+from cryodrgn import fft, mrc, starfile
 
 
 logger = logging.getLogger(__name__)
@@ -219,8 +219,10 @@ class MRCData(data.Dataset):
         if keepreal:
             self.particles_real = particles_real  # noqa: F821
             logger.info(
-                "Normalized real space images by {}".format(particles_real.std())
-            )  # noqa: F821
+                "Normalized real space images by {}".format(
+                    particles_real.std()  # noqa: F821
+                )
+            )
             self.particles_real /= particles_real.std()  # noqa: F821
 
     def __len__(self):

--- a/cryodrgn/lattice.py
+++ b/cryodrgn/lattice.py
@@ -4,11 +4,10 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-
+import logging
 from cryodrgn import utils
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 class Lattice:
@@ -67,7 +66,7 @@ class Lattice:
         assert (
             2 * L + 1 <= self.D
         ), "Mask with size {} too large for lattice with size {}".format(L, self.D)
-        log("Using square lattice of size {}x{}".format(2 * L + 1, 2 * L + 1))
+        logger.info("Using square lattice of size {}x{}".format(2 * L + 1, 2 * L + 1))
         b, e = self.D2 - L, self.D2 + L
         c1 = self.coords.view(self.D, self.D, 3)[b, b]
         c2 = self.coords.view(self.D, self.D, 3)[e, e]
@@ -88,7 +87,7 @@ class Lattice:
         assert (
             2 * R + 1 <= self.D
         ), "Mask with radius {} too large for lattice with size {}".format(R, self.D)
-        vlog("Using circular lattice with radius {}".format(R))
+        logger.debug("Using circular lattice with radius {}".format(R))
 
         r = R / (self.D // 2) * self.extent
         mask = self.coords.pow(2).sum(-1) <= r**2

--- a/cryodrgn/lattice.py
+++ b/cryodrgn/lattice.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 import logging
-from cryodrgn import utils
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -368,10 +368,12 @@ class PositionalDecoder(Decoder):
         """
         # Note: extent should be 0.5 by default, except when a downsampled
         # volume is generated
+        assert extent <= 0.5
+        zdim = 0
+        z = torch.tensor([])
         if zval is not None:
             zdim = len(zval)
-            z = torch.zeros(D**2, zdim, dtype=torch.float32, device=coords.device)
-            z += torch.tensor(zval, dtype=torch.float32, device=coords.device)
+            z = torch.tensor(zval, dtype=torch.float32, device=coords.device)
 
         vol_f = np.zeros((D, D, D), dtype=np.float32)
         assert not self.training
@@ -381,7 +383,7 @@ class PositionalDecoder(Decoder):
         ):
             x = coords + torch.tensor([0, 0, dz], device=coords.device)
             if zval is not None:
-                x = torch.cat((x, zval), dim=-1)
+                x = torch.cat((x, z.expand(x.shape[0], zdim)), dim=-1)
             with torch.no_grad():
                 y = self.forward(x)
                 y = y.view(D, D).cpu().numpy()

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -12,7 +12,6 @@ import cryodrgn.types as types
 from cryodrgn import fft, lie_tools, utils
 from cryodrgn.lattice import Lattice
 
-log = utils.log
 Norm = Sequence[Any]  # mean, std
 
 

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -231,6 +231,12 @@ class DataParallelDecoder(Decoder):
         assert isinstance(module, Decoder)
         return module.eval_volume(*args, **kwargs)
 
+    def forward(self, *args, **kwargs):
+        return self.dp.module.forward(*args, **kwargs)
+
+    def state_dict(self, *args, **kwargs):
+        return self.dp.module.state_dict(*args, **kwargs)
+
 
 class PositionalDecoder(Decoder):
     def __init__(

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -1,6 +1,6 @@
 """Pytorch models"""
 
-from typing import Optional, Tuple, Type, Union, Sequence, Any
+from typing import Optional, Tuple, Type, Sequence, Any
 import numpy as np
 import torch
 from torch import Tensor
@@ -8,7 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 from torch.nn.parallel import DataParallel
-import cryodrgn.types as types
 from cryodrgn import fft, lie_tools, utils
 from cryodrgn.lattice import Lattice
 

--- a/cryodrgn/pose.py
+++ b/cryodrgn/pose.py
@@ -1,14 +1,13 @@
 import pickle
 from typing import Optional, Tuple, Union, List
-
+import logging
 import numpy as np
 import torch
 import torch.nn as nn
 from torch import Tensor
-
 from cryodrgn import lie_tools, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 class PoseTracker(nn.Module):
@@ -111,7 +110,7 @@ class PoseTracker(nn.Module):
             ), "ERROR: Old pose format detected. Translations must be in units of fraction of box."
             trans *= D  # convert from fraction to pixels
         else:
-            log("WARNING: No translations provided")
+            logger.warning("WARNING: No translations provided")
             trans = None
 
         return cls(rots, trans, D, emb_type, device=device)

--- a/cryodrgn/pose_search.py
+++ b/cryodrgn/pose_search.py
@@ -1,14 +1,14 @@
+import logging
 import numpy as np
 import torch
 import torch.nn.functional as F
 from typing import Optional, Union, Tuple
-from cryodrgn import lie_tools, shift_grid, so3_grid, utils
+from cryodrgn import lie_tools, shift_grid, so3_grid
 from cryodrgn.models import unparallelize, HetOnlyVAE
 from cryodrgn.lattice import Lattice
 import torch.nn as nn
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def rot_2d(angle: float, outD: int, device: torch.device) -> torch.Tensor:
@@ -148,7 +148,7 @@ class PoseSearch:
                 assert isinstance(_model, HetOnlyVAE)
                 x = _model.cat_z(x, z)
             x = x.to(device)
-            # log(f"Evaluating model on {x.shape} = {x.nelement() // 3} points")
+            # logger.info(f"Evaluating model on {x.shape} = {x.nelement() // 3} points")
             with torch.no_grad():
                 y_hat = self.model(x)
                 y_hat = y_hat.float()

--- a/cryodrgn/pose_search.py
+++ b/cryodrgn/pose_search.py
@@ -68,7 +68,6 @@ class PoseSearch:
         t_yshift: int = 0,
         device: Optional[torch.device] = None,
     ):
-
         self.model = model
         self.lattice = lattice
         self.base_healpy = base_healpy
@@ -132,7 +131,6 @@ class PoseSearch:
             ctf_i = ctf_i.view(B, 1, 1, -1)[..., mask]  # Bx1x1xYX
 
         def compute_err(images, rot):
-
             adj_angles_inplane = None
             if angles_inplane is not None:
                 # apply a random in-plane rotation from the set

--- a/cryodrgn/templates/cryoDRGN_figures_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_figures_template.ipynb
@@ -1,0 +1,517 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "12d6bdad",
+   "metadata": {},
+   "source": [
+    "# CryoDRGN visualization and figures\n",
+    "\n",
+    "This jupyter notebook provides a template for regenerating and customizing cryoDRGN visualizations and figures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b98dcf23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cryodrgn import analysis\n",
+    "from cryodrgn import utils\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47ec8987",
+   "metadata": {},
+   "source": [
+    "### Load results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "829f0e1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify the workdir and the epoch number (0-based index) to analyze\n",
+    "WORKDIR = '..' \n",
+    "EPOCH = 19 # CHANGE ME"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "551cc751",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load z\n",
+    "z = utils.load_pkl(f'{WORKDIR}/z.{EPOCH}.pkl')\n",
+    "umap = utils.load_pkl(f'{WORKDIR}/analyze.{EPOCH}/umap.pkl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cce7848",
+   "metadata": {},
+   "source": [
+    "# Plot PCA\n",
+    "\n",
+    "Visualize the latent space by principal component analysis (PCA)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81518fa1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pc, pca = analysis.run_pca(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a441bce1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Style 1 -- Scatter\n",
+    "\n",
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(pc[:,0], pc[:,1], alpha=.1, s=1,rasterized=True)\n",
+    "plt.xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "plt.ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))\n",
+    "#plt.savefig('pca_style1.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fe803e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Style 2 -- Scatter with marginals\n",
+    "\n",
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], alpha=.1, s=1,rasterized=True, height=4)\n",
+    "g.ax_joint.set_xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "g.ax_joint.set_ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))\n",
+    "#plt.savefig('pca_style2.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d27280eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Style 3 -- Hexbin/heatmap\n",
+    "\n",
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], height=4, kind='hex')\n",
+    "plt.xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "plt.ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))\n",
+    "#plt.savefig('pca_style3.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cea11ef1",
+   "metadata": {},
+   "source": [
+    "# Plot UMAP\n",
+    "\n",
+    "Visualize the latent space by Uniform Manifold Approximation and Projection (UMAP). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "feb9a1d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Style 1 -- Scatter\n",
+    "\n",
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(umap[:,0], umap[:,1], alpha=.1, s=1,rasterized=True)\n",
+    "plt.xticks([])\n",
+    "plt.yticks([])\n",
+    "plt.xlabel('UMAP1')\n",
+    "plt.ylabel('UMAP2')\n",
+    "#plt.savefig('umap_style1.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e5dd8a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Style 2 -- Scatter with marginal distributions\n",
+    "\n",
+    "g = sns.jointplot(x=umap[:,0], y=umap[:,1], alpha=.1, s=1,rasterized=True, height=4)\n",
+    "g.ax_joint.set_xlabel('UMAP1')\n",
+    "g.ax_joint.set_ylabel('UMAP2')\n",
+    "#plt.savefig('umap_style2.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc4def2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Style 3 -- Hexbin / heatmap\n",
+    "\n",
+    "g = sns.jointplot(x=umap[:,0], y=umap[:,1], kind='hex',height=4)\n",
+    "g.ax_joint.set_xlabel('UMAP1')\n",
+    "g.ax_joint.set_ylabel('UMAP2')\n",
+    "#plt.savefig('umap_style3.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cd98f8e",
+   "metadata": {},
+   "source": [
+    "# Plot kmeans samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e992fca8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load points\n",
+    "K = 20 # CHANGE ME\n",
+    "kmeans_ind = np.loadtxt(f'{WORKDIR}/analyze.{EPOCH}/kmeans{K}/centers_ind.txt', dtype=int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f176e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Default chimerax color map\n",
+    "colors = analysis._get_chimerax_colors(K)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f171d81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot kmeans on PCA\n",
+    "\n",
+    "f, ax = plt.subplots(figsize=(4,4))\n",
+    "plt.scatter(pc[:,0], pc[:,1], alpha=.05, s=1,rasterized=True)\n",
+    "plt.scatter(pc[kmeans_ind,0], pc[kmeans_ind,1], c=colors,edgecolor='black')\n",
+    "labels = np.arange(len(kmeans_ind))\n",
+    "centers = pc[kmeans_ind]\n",
+    "for i in labels:\n",
+    "    ax.annotate(str(i), centers[i, 0:2] + np.array([0.1, 0.1]))\n",
+    "plt.xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "plt.ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))\n",
+    "#plt.savefig('pca_w_kmeans.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4071fd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot kmeans on UMAP\n",
+    "\n",
+    "f, ax = plt.subplots(figsize=(4,4))\n",
+    "plt.scatter(umap[:,0], umap[:,1], alpha=.05, s=1,rasterized=True)\n",
+    "plt.scatter(umap[kmeans_ind,0], umap[kmeans_ind,1], c=colors,edgecolor='black')\n",
+    "labels = np.arange(len(kmeans_ind))\n",
+    "centers = umap[kmeans_ind]\n",
+    "for i in labels:\n",
+    "    ax.annotate(str(i), centers[i, 0:2] + np.array([0.1, 0.1]))\n",
+    "plt.xticks([])\n",
+    "plt.yticks([])\n",
+    "plt.xlabel('UMAP1')\n",
+    "plt.ylabel('UMAP2')\n",
+    "#plt.savefig('umap_w_kmeans.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a3d7052",
+   "metadata": {},
+   "source": [
+    "### Plot PC traversals\n",
+    "\n",
+    "Visualize the PC axes traversals. By default, plot the first two PCs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0576ccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(pc[:,0], pc[:,1], alpha=.1, s=1,rasterized=True)\n",
+    "\n",
+    "# 10 points, from 5th to 95th percentile of PC1 values\n",
+    "t = np.linspace(np.percentile(pc[:,0],5),np.percentile(pc[:,0],95), 10, endpoint=True)\n",
+    "plt.scatter(t,np.zeros(10),c='cornflowerblue',edgecolor='white')\n",
+    "\n",
+    "plt.xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "plt.ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de260d19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(pc[:,0], pc[:,1], alpha=.1, s=1,rasterized=True)\n",
+    "\n",
+    "# 10 points, from 5th to 95th percentile of PC2 values\n",
+    "t = np.linspace(np.percentile(pc[:,1],5),np.percentile(pc[:,1],95),10,endpoint=True)\n",
+    "plt.scatter(np.zeros(10),t,c='cornflowerblue',edgecolor='white')\n",
+    "\n",
+    "plt.xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "plt.ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aefaacef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], alpha=.1, s=1,rasterized=True, height=4)\n",
+    "\n",
+    "t = np.linspace(np.percentile(pc[:,0],5),np.percentile(pc[:,0],95),10,endpoint=True)\n",
+    "g.ax_joint.scatter(x=t,y=np.zeros(10),c='cornflowerblue',edgecolor='white')\n",
+    "\n",
+    "g.ax_joint.set_xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "g.ax_joint.set_ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))\n",
+    "#plt.savefig('pca_pc1_traversal.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3785ef98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.jointplot(x=pc[:,0], y=pc[:,1], alpha=.1, s=1,rasterized=True, height=4)\n",
+    "t = np.linspace(np.percentile(pc[:,1],5),np.percentile(pc[:,1],95),10,endpoint=True)\n",
+    "g.ax_joint.scatter(x=np.zeros(10),y=t,c='cornflowerblue',edgecolor='white')\n",
+    "g.ax_joint.set_xlabel('PC1 ({:.2f})'.format(pca.explained_variance_ratio_[0]))\n",
+    "g.ax_joint.set_ylabel('PC2 ({:.2f})'.format(pca.explained_variance_ratio_[1]))\n",
+    "#plt.savefig('pca_pc2_traversal.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e40a6ef",
+   "metadata": {},
+   "source": [
+    "### Plot UMAP \n",
+    "\n",
+    "Plot the PC axes traversal paths in the UMAP visualization of the latent space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a62cc0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_pc1 = np.loadtxt('pc1/z_values.txt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5298124f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_pc1_on_data, pc1_ind = analysis.get_nearest_point(z, z_pc1)\n",
+    "((z_pc1_on_data - z_pc1)**2).sum(axis=1)**.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ae119ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(umap[:,0], umap[:,1], alpha=.05, s=1,rasterized=True)\n",
+    "plt.scatter(umap[pc1_ind,0], umap[pc1_ind,1], c='cornflowerblue',edgecolor='black')\n",
+    "\n",
+    "plt.xticks([])\n",
+    "plt.yticks([])\n",
+    "plt.xlabel('UMAP1')\n",
+    "plt.ylabel('UMAP2')\n",
+    "#plt.savefig('umap_pc1_traversal.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08d1a2a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(umap[:,0], umap[:,1], alpha=.05, s=1,rasterized=True)\n",
+    "plt.plot(umap[pc1_ind,0], umap[pc1_ind,1], '--',c='k')\n",
+    "plt.scatter(umap[pc1_ind,0], umap[pc1_ind,1], c='cornflowerblue',edgecolor='black')\n",
+    "\n",
+    "plt.xticks([])\n",
+    "plt.yticks([])\n",
+    "plt.xlabel('UMAP1')\n",
+    "plt.ylabel('UMAP2')\n",
+    "#plt.savefig('umap_pc1_traversal_v2.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0571e10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_pc2 = np.loadtxt('pc2/z_values.txt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0eb0c9a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_pc2_on_data, pc2_ind = analysis.get_nearest_point(z, z_pc2)\n",
+    "((z_pc2_on_data - z_pc2)**2).sum(axis=1)**.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b355769f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(umap[:,0], umap[:,1], alpha=.05, s=1,rasterized=True)\n",
+    "plt.scatter(umap[pc2_ind,0], umap[pc2_ind,1], c='cornflowerblue',edgecolor='black')\n",
+    "\n",
+    "plt.xticks([])\n",
+    "plt.yticks([])\n",
+    "plt.xlabel('UMAP1')\n",
+    "plt.ylabel('UMAP2')\n",
+    "#plt.savefig('umap_pc2_traversal.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32a455e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(4,4))\n",
+    "plt.scatter(umap[:,0], umap[:,1], alpha=.05, s=1,rasterized=True)\n",
+    "plt.plot(umap[pc2_ind,0], umap[pc2_ind,1], '--',c='k')\n",
+    "plt.scatter(umap[pc2_ind,0], umap[pc2_ind,1], c='cornflowerblue',edgecolor='black')\n",
+    "\n",
+    "plt.xticks([])\n",
+    "plt.yticks([])\n",
+    "plt.xlabel('UMAP1')\n",
+    "plt.ylabel('UMAP2')\n",
+    "#plt.savefig('umap_pc2_traversal_v2.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0856141",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d1a1181",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b24f0d33",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dea70264",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -2,34 +2,11 @@ from collections.abc import Hashable
 import functools
 import os
 import pickle
-import sys
-from datetime import datetime as dt
+import logging
 from typing import Tuple
 import numpy as np
 
-_verbose = False
-
-
-def log(msg: object) -> None:
-    print("{}     {}".format(dt.now().strftime("%Y-%m-%d %H:%M:%S.%f"), msg))
-    sys.stdout.flush()
-
-
-def vlog(msg: str) -> None:
-    if _verbose:
-        print("{}     {}".format(dt.now().strftime("%Y-%m-%d %H:%M:%S"), msg))
-        sys.stdout.flush()
-
-
-def flog(msg: str, outfile: str) -> None:
-    msg = "{}     {}".format(dt.now().strftime("%Y-%m-%d %H:%M:%S"), msg)
-    print(msg)
-    sys.stdout.flush()
-    try:
-        with open(outfile, "a") as f:
-            f.write(msg + "\n")
-    except Exception as e:
-        log(e)
+logger = logging.getLogger(__name__)
 
 
 class memoized(object):
@@ -71,7 +48,7 @@ def load_pkl(pkl: str):
 
 def save_pkl(data, out_pkl: str, mode: str = "wb") -> None:
     if mode == "wb" and os.path.exists(out_pkl):
-        vlog(f"Warning: {out_pkl} already exists. Overwriting.")
+        logger.warning(f"Warning: {out_pkl} already exists. Overwriting.")
     with open(out_pkl, mode) as f:
         pickle.dump(data, f)
 
@@ -182,7 +159,7 @@ def zero_sphere(vol: np.ndarray) -> np.ndarray:
     assert len(set(vol.shape)) == 1, "volume must be a cube"
     D = vol.shape[0]
     tmp = _zero_sphere_helper(D)
-    vlog("Zeroing {} pixels".format(len(tmp[0])))
+    logger.info("Zeroing {} pixels".format(len(tmp[0])))
     vol[tmp] = 0
     return vol
 

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -50,7 +50,7 @@ def save_pkl(data, out_pkl: str, mode: str = "wb") -> None:
     if mode == "wb" and os.path.exists(out_pkl):
         logger.warning(f"Warning: {out_pkl} already exists. Overwriting.")
     with open(out_pkl, mode) as f:
-        pickle.dump(data, f)
+        pickle.dump(data, f)  # type: ignore
 
 
 def R_from_eman(a: np.ndarray, b: np.ndarray, y: np.ndarray) -> np.ndarray:

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -159,7 +159,7 @@ def zero_sphere(vol: np.ndarray) -> np.ndarray:
     assert len(set(vol.shape)) == 1, "volume must be a cube"
     D = vol.shape[0]
     tmp = _zero_sphere_helper(D)
-    logger.info("Zeroing {} pixels".format(len(tmp[0])))
+    logger.debug("Zeroing {} pixels".format(len(tmp[0])))
     vol[tmp] = 0
     return vol
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,13 +3,15 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "CryoDRGN"
-copyright = "2022, Ellen Zhong"
+copyright = "2023, Ellen Zhong"
 author = "Ellen Zhong"
-release = "1.1.1"
+release = os.environ.get("CRYODRGN_VERSION", "")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to CryoDRGN's documentation!
 
    pages/intro
    pages/installation
+   pages/quickstart
    pages/empiar_tutorial
    pages/landscape_analysis
    pages/large_datasets

--- a/docs/pages/quickstart.md
+++ b/docs/pages/quickstart.md
@@ -1,0 +1,146 @@
+# cryoDRGN2 quickstart
+
+## Installation
+
+CryoDRGN2 commands are now natively available in the top-of-tree on github, and will be available in the next official cryoDRGN version 2.0 release.
+
+- Older installation instructions
+
+    The cryodrgn2 codebase is an extension to the publicly available cryodrgn version, so you can install the software in the same conda environment and still have all the cryodrgn1 functionality.
+
+    ```bash
+    # activate existing cryodrgn conda environment, or create a new one following the installation instruction on the github
+    conda activate cryodrgn
+
+    # install an additional requirement
+    conda install healpy -c conda-forge
+
+    # install the library
+    pip install .
+    ```
+
+    Note: After installing, now when you run cryodrgn1, i.e. `cryodrgn train_vae`, there is one updated default parameter from the publicly available v0.3.4 (`—-pe-type gaussian` instead of `--pe-type geom_lowf`). This uses an updated architecture that will be the new default in cryoDRGN v1.0 (faster training, higher resolution). I’m mentioning it here in case you want to stick with the previous default.
+
+
+## Running cryoDRGN2
+
+There are two commands for ab initio reconstruction:  `cryodrgn abinit_homo` (homogeneous ab initio reconstruction) and `cryodrgn abinit_het` (heterogeneous ab initio reconstruction):
+
+```bash
+# homogeneous ab initio
+cryodrgn abinit_homo -h
+
+# heterogeneous ab initio
+cryodrgn abinit_het -h
+```
+
+### Setup
+
+- Downsample your particles to a box size of 128 either with `cryodrgn downsample` or with other tools.
+- If you have a very large dataset (>500k images), I would recommend training on a subset of particles for initial testing. Use `cryodrgn_utils select_random` to select a random subset of particles.
+
+    ```bash
+    # get a random selection of 200k particles from a dataset of 1,423,124 particles
+    cryodrgn_utils select_random 1423124 -n 200000 -o ind200k.pkl
+    ```
+
+    - You can then train on only the random subset with the argument `--ind ind200k.pkl`
+- For reference, ab initio heterogeneous reconstruction of a recent dataset of ~218k 128x128 particles took 20 hours to train (1 V100 GPU).
+
+### Example usage
+
+```bash
+# homogeneous reconstruction
+cryodrgn abinit_homo [particles] --ctf [ctf.pkl] -o [output_directory]  >> output.log
+
+# heterogeneous reconstruction
+cryodrgn abinit_het [particles] --ctf [ctf.pkl] --zdim 8 -o [output_directory]  >> output.log
+```
+
+### Note on homogeneous reconstruction
+
+We have found that cryoDRGN2’s homogeneous reconstruction can work better than traditional ab initio approaches for challenging *heterogeneous* datasets, e.g. the RAG1-RAG2 complex (EMPIAR-10049) and the pre-catalytic spliceosome (EMPIAR-10076), potentially due regularization properties of the neural model. It may be interesting to try `cryodrgn abinit_homo`  for generating a consensus reconstruction or initial model. Please let us know if you find something interesting!
+
+### Note on training settings
+
+- The default translational search extent is +/- 10 pixels. If your particles are not well-centered, you can use a wider search extent, e.g. +/- 40 pixels ( `--t-extent 40`).
+- Poses are updated every 5 epochs (change this setting with `--ps-freq`)
+- The default pose search settings are not tuned to produce super high-resolution volumes (a tradeoff of accuracy vs. compute speed).
+- The default training time is 30 epochs. A typical use case is to run for 30 epochs, check the results (`cryodrgn analyze`), then extend training to 60 epochs. You can extend by rerunning with `-n 60 --load latest`. If your dataset is very large, you may want to reduce `--ps-freq` and `-n`.
+- During training, pose search epochs will get successively slower. This is because the default parameter `--l-ramp-epochs 25` increases the max resolution from a Fourier radius of 12 pix to 32 pix over the first 25 epochs of training.
+    - Example training time course (1 V100 GPU)
+
+        ```bash
+        2022-01-20 18:00:59     # =====> Epoch: 1 Average gen loss = 0.8816, KLD = 0.8981, total loss = 0.8817; Finished in 1:13:20.758477
+        2022-01-20 18:02:07     Using previous iteration poses
+        2022-01-20 18:15:20     # =====> Epoch: 2 Average gen loss = 0.8825, KLD = 1.6127, total loss = 0.8826; Finished in 0:13:13.168348
+        2022-01-20 18:16:27     Using previous iteration poses
+        2022-01-20 18:29:41     # =====> Epoch: 3 Average gen loss = 0.8818, KLD = 1.8766, total loss = 0.8819; Finished in 0:13:14.378679
+        2022-01-20 18:30:48     Using previous iteration poses
+        2022-01-20 18:44:02     # =====> Epoch: 4 Average gen loss = 0.8811, KLD = 2.0323, total loss = 0.8812; Finished in 0:13:13.887047
+        2022-01-20 18:45:09     Using previous iteration poses
+        2022-01-20 18:58:23     # =====> Epoch: 5 Average gen loss = 0.8808, KLD = 2.1141, total loss = 0.8809; Finished in 0:13:14.298884
+        2022-01-20 20:30:25     # =====> Epoch: 6 Average gen loss = 0.8783, KLD = 2.0354, total loss = 0.8784; Finished in 1:30:55.173547
+        2022-01-20 20:31:46     Using previous iteration poses
+        2022-01-20 20:45:00     # =====> Epoch: 7 Average gen loss = 0.878, KLD = 2.1416, total loss = 0.8782; Finished in 0:13:14.021982
+        2022-01-20 20:46:20     Using previous iteration poses
+        2022-01-20 20:59:35     # =====> Epoch: 8 Average gen loss = 0.8778, KLD = 2.1859, total loss = 0.8780; Finished in 0:13:14.906471
+        2022-01-20 21:00:43     Using previous iteration poses
+        2022-01-20 21:13:57     # =====> Epoch: 9 Average gen loss = 0.8776, KLD = 2.2222, total loss = 0.8778; Finished in 0:13:14.233966
+        2022-01-20 21:15:04     Using previous iteration poses
+        2022-01-20 21:28:19     # =====> Epoch: 10 Average gen loss = 0.8775, KLD = 2.2439, total loss = 0.8776; Finished in 0:13:14.907938
+        2022-01-20 23:28:54     # =====> Epoch: 11 Average gen loss = 0.8769, KLD = 2.2428, total loss = 0.8771; Finished in 1:59:27.793799
+        2022-01-20 23:30:01     Using previous iteration poses
+        2022-01-20 23:43:15     # =====> Epoch: 12 Average gen loss = 0.8769, KLD = 2.3463, total loss = 0.8770; Finished in 0:13:14.289931
+        2022-01-20 23:44:23     Using previous iteration poses
+        2022-01-20 23:57:37     # =====> Epoch: 13 Average gen loss = 0.8767, KLD = 2.3692, total loss = 0.8769; Finished in 0:13:14.531232
+        2022-01-20 23:58:45     Using previous iteration poses
+        2022-01-21 00:11:59     # =====> Epoch: 14 Average gen loss = 0.8766, KLD = 2.3928, total loss = 0.8768; Finished in 0:13:14.821960
+        2022-01-21 00:13:07     Using previous iteration poses
+        2022-01-21 00:26:22     # =====> Epoch: 15 Average gen loss = 0.8765, KLD = 2.4063, total loss = 0.8767; Finished in 0:13:15.422771
+        2022-01-21 02:58:58     # =====> Epoch: 16 Average gen loss = 0.8762, KLD = 2.3726, total loss = 0.8764; Finished in 2:31:28.195825
+        2022-01-21 03:00:05     Using previous iteration poses
+        2022-01-21 03:13:07     # =====> Epoch: 17 Average gen loss = 0.8762, KLD = 2.4672, total loss = 0.8764; Finished in 0:13:02.429271
+        2022-01-21 03:14:14     Using previous iteration poses
+        2022-01-21 03:27:17     # =====> Epoch: 18 Average gen loss = 0.876, KLD = 2.4911, total loss = 0.8762; Finished in 0:13:02.989886
+        2022-01-21 03:28:24     Using previous iteration poses
+        2022-01-21 03:41:27     # =====> Epoch: 19 Average gen loss = 0.876, KLD = 2.5077, total loss = 0.8762; Finished in 0:13:02.990354
+        2022-01-21 03:42:34     Using previous iteration poses
+        2022-01-21 03:55:37     # =====> Epoch: 20 Average gen loss = 0.8759, KLD = 2.5235, total loss = 0.8761; Finished in 0:13:02.651984
+        2022-01-21 07:09:20     # =====> Epoch: 21 Average gen loss = 0.8756, KLD = 2.4737, total loss = 0.8758; Finished in 3:12:35.716970
+        2022-01-21 07:10:27     Using previous iteration poses
+        2022-01-21 07:23:30     # =====> Epoch: 22 Average gen loss = 0.8757, KLD = 2.5532, total loss = 0.8759; Finished in 0:13:02.696251
+        2022-01-21 07:24:37     Using previous iteration poses
+        2022-01-21 07:37:40     # =====> Epoch: 23 Average gen loss = 0.8756, KLD = 2.5753, total loss = 0.8758; Finished in 0:13:03.271111
+        2022-01-21 07:38:47     Using previous iteration poses
+        2022-01-21 07:51:52     # =====> Epoch: 24 Average gen loss = 0.8755, KLD = 2.5935, total loss = 0.8757; Finished in 0:13:05.296650
+        2022-01-21 07:52:59     Using previous iteration poses
+        2022-01-21 08:06:03     # =====> Epoch: 25 Average gen loss = 0.8755, KLD = 2.6057, total loss = 0.8757; Finished in 0:13:03.414230
+        2022-01-21 12:13:51     # =====> Epoch: 26 Average gen loss = 0.8753, KLD = 2.5529, total loss = 0.8755; Finished in 4:06:41.267859
+        2022-01-21 12:14:59     Using previous iteration poses
+        2022-01-21 12:28:01     # =====> Epoch: 27 Average gen loss = 0.8753, KLD = 2.6321, total loss = 0.8755; Finished in 0:13:02.813657
+        2022-01-21 12:29:09     Using previous iteration poses
+        2022-01-21 12:42:11     # =====> Epoch: 28 Average gen loss = 0.8752, KLD = 2.6528, total loss = 0.8754; Finished in 0:13:02.511731
+        2022-01-21 12:43:18     Using previous iteration poses
+        2022-01-21 12:56:21     # =====> Epoch: 29 Average gen loss = 0.8752, KLD = 2.6635, total loss = 0.8754; Finished in 0:13:02.821824
+        2022-01-21 12:57:28     Using previous iteration poses
+        2022-01-21 13:10:31     # =====> Epoch: 30 Average gen loss = 0.8751, KLD = 2.6744, total loss = 0.8753; Finished in 0:13:02.737088
+        ```
+
+### Questions and contact
+
+If you have any questions about the method, feel free to contact either Ellen (zhonge@princeton.edu) or Adam (alerer@fb.com).
+
+For questions on how to use this software, please file a GitHub issue:
+
+[https://github.com/zhonge/cryodrgn/issues](https://github.com/zhonge/cryodrgn/issues)
+
+Or post in the new cryoDRGN Google Group: [https://groups.google.com/g/cryodrgn](https://groups.google.com/g/cryodrgn).
+
+CryoDRGN2 software was developed by Ellen Zhong & Adam Lerer with software support from Vineet Bansal.
+
+### Reference
+
+Zhong, Lerer, Davis, Berger. ICCV 2021.
+
+[https://openaccess.thecvf.com/content/ICCV2021/html/Zhong_CryoDRGN2_Ab_Initio_Neural_Reconstruction_of_3D_Protein_Structures_From_ICCV_2021_paper.html](https://openaccess.thecvf.com/content/ICCV2021/html/Zhong_CryoDRGN2_Ab_Initio_Neural_Reconstruction_of_3D_Protein_Structures_From_ICCV_2021_paper.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "build",
     "myst-parser",
     "pre-commit",
-    "pyright@1.1.300",
+    "pyright==1.1.300",
     "pytest>=6",
     "sphinx",
     "sphinx-book-theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "build",
     "myst-parser",
     "pre-commit",
-    "pyright",
+    "pyright@1.1.300",
     "pytest>=6",
     "sphinx",
     "sphinx-book-theme",

--- a/testing/test_abinit.sh
+++ b/testing/test_abinit.sh
@@ -4,6 +4,8 @@ set -e
 # https://stackoverflow.com/questions/59895
 B=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-python $B/../cryodrgn/commands/abinit_het.py $B/data/hand.mrcs --zdim 8 -o $B/output/test --multigpu --domain hartley
-python $B/../cryodrgn/commands/train_nn.py $B/data/hand.mrcs -o $B/output/test --domain hartley --uninvert-data --poses data/hand_rot.pkl --dim 256
-python $B/../cryodrgn/commands/abinit_homo.py $B/data/hand.mrcs -o $B/output/test --load $B/output/test/weights.pkl --domain hartley -n 40 --uninvert-data
+python $B/../cryodrgn/commands/abinit_het.py $B/data/hand.mrcs --zdim 8 -o $B/output/test_abinit_het --multigpu --domain hartley
+python $B/../cryodrgn/commands/analyze.py $B/output/test_abinit_het 0
+
+python $B/../cryodrgn/commands/train_nn.py $B/data/hand.mrcs -o $B/output/test_abinit_homo --domain hartley --uninvert-data --poses data/hand_rot.pkl --dim 256
+python $B/../cryodrgn/commands/abinit_homo.py $B/data/hand.mrcs -o $B/output/test_abinit_homo --load $B/output/test/weights.pkl --domain hartley -n 40 --uninvert-data

--- a/tests/test_abinit.py
+++ b/tests/test_abinit.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import os.path
-from cryodrgn.commands import abinit_het, abinit_homo, backproject_voxel
+from cryodrgn.commands import abinit_het, abinit_homo, analyze, backproject_voxel
 
 DATA_FOLDER = os.path.join(os.path.dirname(__file__), "..", "testing", "data")
 
@@ -51,6 +51,14 @@ def test_abinit_het_and_backproject():
             + abinit_args
         )
     )
+
+    args = analyze.add_args(argparse.ArgumentParser()).parse_args(
+        [
+            "output/abinit_het",
+            "29",  # Epoch number to analyze - 0-indexed
+        ]
+    )
+    analyze.main(args)
 
     args = backproject_voxel.add_args(argparse.ArgumentParser()).parse_args(
         [

--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -55,8 +55,6 @@ def test_run(mrcs_file, poses_file):
             "3",  # Number of principal component traversals to generate
             "--ksample",
             "14",  # Number of kmeans samples to generate
-            "--device",
-            "0",
             "--vol-start-index",
             "1",
         ]
@@ -68,8 +66,6 @@ def test_run(mrcs_file, poses_file):
         [
             "output",
             "19",  # Epoch number to analyze - 0-indexed
-            "--device",
-            "0",
             "--sketch-size",
             "10",  # Number of volumes to generate for analysis
             "--downsample",

--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -34,7 +34,7 @@ def test_run(mrcs_file, poses_file):
             "--lr",
             ".0001",
             "--num-epochs",
-            "20",
+            "3",
             "--seed",
             "0",
             "--poses",
@@ -43,14 +43,40 @@ def test_run(mrcs_file, poses_file):
             "10",
             "--pe-type",
             "gaussian",
+            "--multigpu",
         ]
     )
     train_vae.main(args)
 
+    # Load a check-pointed model and run for another epoch, this time without --multigpu
+    train_vae.main(
+        train_vae.add_args(argparse.ArgumentParser()).parse_args(
+            [
+                mrcs_file,
+                "-o",
+                "output",
+                "--lr",
+                ".0001",
+                "--num-epochs",
+                "4",
+                "--seed",
+                "0",
+                "--poses",
+                poses_file,
+                "--zdim",
+                "10",
+                "--pe-type",
+                "gaussian",
+                "--load",
+                "output/weights.2.pkl",
+            ]
+        )
+    )
+
     args = analyze.add_args(argparse.ArgumentParser()).parse_args(
         [
             "output",
-            "19",  # Epoch number to analyze - 0-indexed
+            "2",  # Epoch number to analyze - 0-indexed
             "--pc",
             "3",  # Number of principal component traversals to generate
             "--ksample",
@@ -61,11 +87,11 @@ def test_run(mrcs_file, poses_file):
     )
     analyze.main(args)
 
-    shutil.rmtree("output/landscape.19", ignore_errors=True)
+    shutil.rmtree("output/landscape.3", ignore_errors=True)
     args = analyze_landscape.add_args(argparse.ArgumentParser()).parse_args(
         [
             "output",
-            "19",  # Epoch number to analyze - 0-indexed
+            "2",  # Epoch number to analyze - 0-indexed
             "--sketch-size",
             "10",  # Number of volumes to generate for analysis
             "--downsample",
@@ -76,12 +102,12 @@ def test_run(mrcs_file, poses_file):
             "1",
         ]
     )
-    shutil.rmtree("output/landscape.19", ignore_errors=True)
+    shutil.rmtree("output/landscape.3", ignore_errors=True)
     analyze_landscape.main(args)
 
     args = graph_traversal.add_args(argparse.ArgumentParser()).parse_args(
         [
-            "output/z.19.pkl",
+            "output/z.3.pkl",
             "--anchors",
             "22",
             "49",
@@ -107,7 +133,7 @@ def test_run(mrcs_file, poses_file):
 
     args = eval_vol.add_args(argparse.ArgumentParser()).parse_args(
         [
-            "output/weights.19.pkl",
+            "output/weights.3.pkl",
             "--config",
             "output/config.pkl",
             "--zfile",

--- a/tests/test_train_nn.py
+++ b/tests/test_train_nn.py
@@ -1,0 +1,52 @@
+import os.path
+import argparse
+import pytest
+from cryodrgn.mrc import parse_mrc
+from cryodrgn.commands import train_nn
+
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), "..", "testing", "data")
+
+
+@pytest.fixture
+def mrcs_data():
+    return parse_mrc(f"{DATA_FOLDER}/toy_projections.mrcs", lazy=False)[0]
+
+
+@pytest.fixture
+def poses_file():
+    return f"{DATA_FOLDER}/toy_angles.pkl"
+
+
+def test_train_nn(mrcs_data, poses_file):
+    args = train_nn.add_args(argparse.ArgumentParser()).parse_args(
+        [
+            f"{DATA_FOLDER}/toy_projections.mrcs",
+            "--outdir",
+            "output/train_nn",
+            "--poses",
+            poses_file,
+            "--num-epochs",
+            "3",
+            "--no-amp",
+            "--multigpu",
+        ]
+    )
+    train_nn.main(args)
+
+    # Load a check-pointed model, this time with no --multigpu
+    train_nn.main(
+        train_nn.add_args(argparse.ArgumentParser()).parse_args(
+            [
+                f"{DATA_FOLDER}/toy_projections.mrcs",
+                "--outdir",
+                "output/train_nn",
+                "--poses",
+                poses_file,
+                "--num-epochs",
+                "5",
+                "--no-amp",
+                "--load",
+                "output/train_nn/weights.2.pkl",
+            ]
+        )
+    )


### PR DESCRIPTION
Added the quickstart page for `cryoDRGN2` from notion.so.

This should not be merged yet, since I had a few points to discuss in person when we get a chance:
 - *Older installation instructions* - not sure why this section exists since its no different from how one would install `cryoDRGN` anyway.
 - Not sure why `v0.3.4` is mentioned specifically and what's *publicly available* about it. (Aren't all versions publicly available?)
 - Need some clarification on what exactly we mean by `cryoDRGN1` and `cryoDRGN2` in a setting where the package name doesn't change at all.
 - Using `cryoDRGN2` will date the documentation - perhaps there's a better way? 