### PR TITLE
switched to logging module; log/vlog/flog calls gone

### DIFF
--- a/analysis_scripts/fsc.py
+++ b/analysis_scripts/fsc.py
@@ -1,13 +1,12 @@
 """Compute FSC between two volumes"""
 
 import argparse
-
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
+from cryodrgn import fft, mrc
 
-from cryodrgn import fft, mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -45,7 +44,7 @@ def main(args):
     vol1 = fft.fftn_center(vol1)
     vol2 = fft.fftn_center(vol2)
 
-    # log(r[D//2, D//2, D//2:])
+    # logger.info(r[D//2, D//2, D//2:])
     prev_mask = np.zeros((D, D, D), dtype=bool)
     fsc = [1.0]
     for i in range(1, D // 2):
@@ -63,15 +62,15 @@ def main(args):
     if args.o:
         np.savetxt(args.o, res)
     else:
-        log(res)
+        logger.info(res)
 
     w = np.where(fsc < 0.5)
     if w:
-        log("0.5: {}".format(1 / x[w[0]] * args.Apix))
+        logger.info("0.5: {}".format(1 / x[w[0]] * args.Apix))
 
     w = np.where(fsc < 0.143)
     if w:
-        log("0.143: {}".format(1 / x[w[0]] * args.Apix))
+        logger.info("0.143: {}".format(1 / x[w[0]] * args.Apix))
 
     if args.plot:
         plt.plot(x, fsc)

--- a/cryodrgn/__init__.py
+++ b/cryodrgn/__init__.py
@@ -16,10 +16,12 @@ _ROOT = os.path.abspath(os.path.dirname(__file__))
 logging.config.dictConfig(
     {
         "version": 1,
-        "formatters": {"standard": {"format": "%(asctime)s     %(message)s"}},
+        "formatters": {
+            "standard": {"format": "%(asctime)s %(message)s (%(filename)s:%(lineno)d)"}
+        },
         "handlers": {
             "default": {
-                "level": "INFO",
+                "level": "NOTSET",
                 "formatter": "standard",
                 "class": "logging.StreamHandler",
                 "stream": "ext://sys.stdout",

--- a/cryodrgn/__init__.py
+++ b/cryodrgn/__init__.py
@@ -1,4 +1,6 @@
 import os
+import logging.config
+
 
 # The _version.py file is managed by setuptools-scm
 #   and is not in version control.
@@ -9,3 +11,20 @@ except ModuleNotFoundError:
     __version__ = "src"
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
+
+
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "formatters": {"standard": {"format": "%(asctime)s     %(message)s"}},
+        "handlers": {
+            "default": {
+                "level": "INFO",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "loggers": {"": {"handlers": ["default"], "level": "INFO"}},
+    }
+)

--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -1,5 +1,6 @@
 import argparse
 import re
+import logging
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure, Axes
 import numpy as np
@@ -12,7 +13,8 @@ from sklearn.manifold import TSNE
 from sklearn.mixture import GaussianMixture
 from typing import Optional, Union, Tuple, List
 from cryodrgn.commands import eval_vol
-from cryodrgn.utils import log
+
+logger = logging.getLogger(__name__)
 
 
 def parse_loss(f: str) -> np.ndarray:
@@ -36,8 +38,8 @@ def parse_loss(f: str) -> np.ndarray:
 def run_pca(z: np.ndarray) -> Tuple[np.ndarray, PCA]:
     pca = PCA(z.shape[1])
     pca.fit(z)
-    log("Explained variance ratio:")
-    log(pca.explained_variance_ratio_)
+    logger.info("Explained variance ratio:")
+    logger.info(pca.explained_variance_ratio_)
     pc = pca.transform(z)
     return pc, pca
 
@@ -83,7 +85,9 @@ def run_tsne(
     z: np.ndarray, n_components: int = 2, perplexity: float = 1000
 ) -> np.ndarray:
     if len(z) > 10000:
-        log("WARNING: {} datapoints > {}. This may take awhile.".format(len(z), 10000))
+        logger.warning(
+            "WARNING: {} datapoints > {}. This may take awhile.".format(len(z), 10000)
+        )
     z_embedded = TSNE(n_components=n_components, perplexity=perplexity).fit_transform(z)
     return z_embedded
 

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -685,6 +685,9 @@ def get_latest(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -1126,6 +1129,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import pickle
 import sys
+import logging
 from datetime import datetime as dt
 import numpy as np
 import torch
@@ -21,8 +22,7 @@ from cryodrgn.losses import EquivarianceLoss
 from cryodrgn.models import HetOnlyVAE, unparallelize
 from cryodrgn.pose_search import PoseSearch
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -57,7 +57,7 @@ def add_args(parser):
         help="Logging interval in N_IMGS (default: %(default)s)",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increaes verbosity"
+        "-v", "--verbose", action="store_true", help="Increase verbosity"
     )
     parser.add_argument(
         "--seed", type=int, default=np.random.randint(0, 100000), help="Random seed"
@@ -504,8 +504,8 @@ def train(
 
     kld = -0.5 * torch.mean(1 + z_logvar - z_mu.pow(2) - z_logvar.exp())
     if torch.isnan(kld):
-        log(z_mu[0])
-        log(z_logvar[0])
+        logger.info(z_mu[0])
+        logger.info(z_logvar[0])
         raise RuntimeError("KLD is nan")
 
     if beta_control is None:
@@ -671,16 +671,16 @@ def sort_poses(poses):
     return (rot,)
 
 
-def get_latest(args, flog):
-    flog("Detecting latest checkpoint...")
+def get_latest(args):
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     i = args.load.split(".")[-2]
     args.load_poses = f"{args.outdir}/pose.{i}.pkl"
     assert os.path.exists(args.load_poses)
-    flog(f"Loading {args.load_poses}")
+    logger.info(f"Loading {args.load_poses}")
     return args
 
 
@@ -688,15 +688,13 @@ def main(args):
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -705,9 +703,9 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        log("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # set beta schedule
     try:
@@ -720,13 +718,13 @@ def main(args):
 
     # load index filter
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
 
     # load dataset
-    flog(f"Loading dataset from {args.particles}")
+    logger.info(f"Loading dataset from {args.particles}")
     if args.tilt is None:
         tilt = None
         args.use_real = args.encode_mode == "conv"
@@ -750,15 +748,12 @@ def main(args):
                 window=args.window,
                 datadir=args.datadir,
                 window_r=args.window_r,
-                flog=flog,
             )
         elif args.preprocessed:
-            flog(
+            logger.info(
                 "Using preprocessed inputs. Ignoring any --window/--invert-data options"
             )
-            data = dataset.PreprocessedMRCData(
-                args.particles, norm=args.norm, ind=ind, flog=flog
-            )
+            data = dataset.PreprocessedMRCData(args.particles, norm=args.norm, ind=ind)
         else:
             data = dataset.MRCData(
                 args.particles,
@@ -770,7 +765,6 @@ def main(args):
                 datadir=args.datadir,
                 max_threads=args.max_threads,
                 window_r=args.window_r,
-                flog=flog,
             )
 
     # Tilt series data -- lots of unsupported features
@@ -792,7 +786,6 @@ def main(args):
             keepreal=args.use_real,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = torch.tensor(utils.xrot(args.tilt_deg).astype(np.float32), device=device)
     Nimg = data.N
@@ -803,7 +796,7 @@ def main(args):
 
     # load ctf
     if args.ctf is not None:
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -829,8 +822,8 @@ def main(args):
 
     model = make_model(args, lattice, enc_mask, in_dim)
     model.to(device)
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
@@ -838,12 +831,12 @@ def main(args):
 
     # parallelize
     if args.multigpu and torch.cuda.device_count() > 1:
-        log(f"Using {torch.cuda.device_count()} GPUs!")
+        logger.info(f"Using {torch.cuda.device_count()} GPUs!")
         args.batch_size *= torch.cuda.device_count()
-        log(f"Increasing batch size to {args.batch_size}")
+        logger.info(f"Increasing batch size to {args.batch_size}")
         model = DataParallel(model)
     elif args.multigpu:
-        log(
+        logger.warning(
             f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
         )
 
@@ -859,12 +852,12 @@ def main(args):
     optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)
 
     if args.load == "latest":
-        args = get_latest(args, flog)
+        args = get_latest(args)
 
     sorted_poses = []
     if args.load:
         args.pretrain = 0
-        flog("Loading checkpoint from {}".format(args.load))
+        logger.info("Loading checkpoint from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -918,7 +911,7 @@ def main(args):
 
     # pretrain decoder with random poses
     global_it = 0
-    flog("Using random poses for {} iterations".format(args.pretrain))
+    logger.info("Using random poses for {} iterations".format(args.pretrain))
     while global_it < args.pretrain:
         for batch in data_iterator:
             global_it += len(batch[0])
@@ -929,13 +922,13 @@ def main(args):
             )
             loss = pretrain(model, lattice, optim, batch, tilt=ps.tilt, zdim=args.zdim)
             if global_it % args.log_interval == 0:
-                flog(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
+                logger.info(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
             if global_it > args.pretrain:
                 break
 
     # reset model after pretraining
     if args.reset_optim_after_pretrain:
-        flog(">> Resetting optim after pretrain")
+        logger.info(">> Resetting optim after pretrain")
         optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)
 
     # training loop
@@ -965,17 +958,17 @@ def main(args):
                 L_model = ps.Lmax
 
         if args.reset_model_every and (epoch - 1) % args.reset_model_every == 0:
-            flog(">> Resetting model")
+            logger.info(">> Resetting model")
             model = make_model(args, lattice, enc_mask, in_dim)
 
         if args.reset_optim_every and (epoch - 1) % args.reset_optim_every == 0:
-            flog(">> Resetting optim")
+            logger.info(">> Resetting optim")
             optim = torch.optim.Adam(
                 model.parameters(), lr=args.lr, weight_decay=args.wd
             )
 
         if epoch % args.ps_freq != 0:
-            flog("Using previous iteration poses")
+            logger.info("Using previous iteration poses")
         for batch in data_iterator:
             ind = batch[-1]
             ind_np = ind.cpu().numpy()
@@ -1036,7 +1029,7 @@ def main(args):
                     if eq_loss is not None and lamb is not None
                     else ""
                 )
-                log(
+                logger.info(
                     f"# [Train Epoch: {epoch+1}/{num_epochs}] [{batch_it}/{Nimg} images] gen loss={gen_loss:.4f}, "
                     f"kld={kld:.4f}, beta={beta:.4f}, {eq_log}loss={loss:.4f}"
                 )
@@ -1046,7 +1039,7 @@ def main(args):
             if args.equivariance
             else ""
         )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average gen loss = {:.4}, KLD = {:.4f}, {}total loss = {:.4f}; Finished in {}".format(
                 epoch + 1,
                 gen_loss_accum / Nimg,
@@ -1125,7 +1118,7 @@ def main(args):
             )
 
         td = dt.now() - t1
-        flog(
+        logger.info(
             "Finished in {} ({} per epoch)".format(td, td / (num_epochs - start_epoch))
         )
 
@@ -1133,5 +1126,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -447,6 +447,9 @@ def make_model(args, D: int):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -728,6 +731,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -8,7 +8,7 @@ import pickle
 import signal
 import sys
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
 import torch.nn as nn
@@ -19,9 +19,7 @@ from cryodrgn import ctf, dataset, lie_tools, models, mrc, utils
 from cryodrgn.lattice import Lattice
 from cryodrgn.pose_search import PoseSearch
 
-log = utils.log
-vlog = utils.vlog
-
+logger = logging.getLogger(__name__)
 
 # def debug_signal_handler(signal, frame):
 #     import pdb
@@ -419,17 +417,17 @@ def train(
     return loss.item(), save_pose, base_pose
 
 
-def get_latest(args, flog):
+def get_latest(args):
     # assumes args.num_epochs > latest checkpoint
-    flog("Detecting latest checkpoint...")
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     i = args.load.split(".")[-2]
     args.load_poses = f"{args.outdir}/pose.{i}.pkl"
     assert os.path.exists(args.load_poses)  # Might need to relax this assert
-    flog(f"Loading {args.load_poses}")
+    logger.info(f"Loading {args.load_poses}")
     return args
 
 
@@ -452,15 +450,14 @@ def main(args):
     t1 = dt.now()
     if not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -469,13 +466,13 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        flog("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # load the particles
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         args.ind = pickle.load(open(args.ind, "rb"))
     if args.tilt is None:
         data = dataset.MRCData(
@@ -485,7 +482,6 @@ def main(args):
             ind=args.ind,
             window=args.window,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = None
     else:
@@ -497,7 +493,6 @@ def main(args):
             ind=args.ind,
             window=args.window,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = torch.tensor(utils.xrot(args.tilt_deg).astype(np.float32), device=device)
     D = data.D
@@ -505,7 +500,7 @@ def main(args):
 
     # load ctf
     if args.ctf is not None:
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[args.ind]
@@ -544,8 +539,8 @@ def main(args):
             t_yshift=args.t_yshift,
             device=device,
         )
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
@@ -555,7 +550,7 @@ def main(args):
     sorted_poses = []
     if args.load:
         args.pretrain = 0
-        flog("Loading checkpoint from {}".format(args.load))
+        logger.info("Loading checkpoint from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -578,7 +573,7 @@ def main(args):
 
     # pretrain decoder with random poses
     global_it = 0
-    flog("Using random poses for {} iterations".format(args.pretrain))
+    logger.info("Using random poses for {} iterations".format(args.pretrain))
     while global_it < args.pretrain:
         for batch in data_iterator:
             global_it += len(batch[0])
@@ -589,7 +584,7 @@ def main(args):
             )
             loss = pretrain(model, lattice, optim, batch, tilt=ps.tilt)
             if global_it % args.log_interval == 0:
-                flog(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
+                logger.info(f"[Pretrain Iteration {global_it}] loss={loss:4f}")
             if global_it > args.pretrain:
                 break
     out_mrc = "{}/pretrain.reconstruct.mrc".format(args.outdir)
@@ -599,7 +594,7 @@ def main(args):
 
     # reset model after pretraining
     if args.reset_optim_after_pretrain:
-        flog(">> Resetting optim after pretrain")
+        logger.info(">> Resetting optim after pretrain")
         optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)
 
     # training loop
@@ -622,17 +617,17 @@ def main(args):
             ps.Lmax = min(Lramp, args.l_end)
 
         if args.reset_model_every and (epoch - 1) % args.reset_model_every == 0:
-            flog(">> Resetting model")
+            logger.info(">> Resetting model")
             model = make_model(args, D)
 
         if args.reset_optim_every and (epoch - 1) % args.reset_optim_every == 0:
-            flog(">> Resetting optim")
+            logger.info(">> Resetting optim")
             optim = torch.optim.Adam(
                 model.parameters(), lr=args.lr, weight_decay=args.wd
             )
 
         if epoch % args.ps_freq != 0:
-            flog("Using previous iteration poses")
+            logger.info("Using previous iteration poses")
         for batch in data_iterator:
             ind = batch[-1]
             ind_np = ind.cpu().numpy()
@@ -674,12 +669,12 @@ def main(args):
             # logging
             loss_accum += loss_item * len(batch[0])
             if batch_it % args.log_interval == 0:
-                log(
+                logger.info(
                     "# [Train Epoch: {}/{}] [{}/{} images] loss={:.4f}".format(
                         epoch + 1, args.num_epochs, batch_it, Nimg, loss_item
                     )
                 )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average loss = {:.4}; Finished in {}".format(
                 epoch + 1, loss_accum / Nimg, dt.now() - t2
             )
@@ -723,7 +718,7 @@ def main(args):
         )
 
         td = dt.now() - t1
-        flog(
+        logger.info(
             "Finished in {} ({} per epoch)".format(
                 td, td / (args.num_epochs - start_epoch)
             )
@@ -733,5 +728,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_images.py
+++ b/cryodrgn/commands/eval_images.py
@@ -197,6 +197,9 @@ def eval_batch(
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
 
     # make output directories
@@ -364,6 +367,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_images.py
+++ b/cryodrgn/commands/eval_images.py
@@ -6,18 +6,16 @@ import os
 import pickle
 import pprint
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-
 from cryodrgn import config, ctf, dataset, utils
 from cryodrgn.commands.train_vae import loss_function, preprocess_input, run_batch
 from cryodrgn.models import HetOnlyVAE
 from cryodrgn.pose import PoseTracker
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -210,13 +208,13 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    log("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        log("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
-    log(args)
+    logger.info(args)
     cfg = config.overwrite_config(args.config, args)
-    log("Loaded configuration:")
+    logger.info("Loaded configuration:")
     pprint.pprint(cfg)
 
     zdim = cfg["model_args"]["zdim"]
@@ -224,7 +222,7 @@ def main(args):
 
     # load the particles
     if args.ind is not None:
-        log("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
@@ -287,7 +285,7 @@ def main(args):
             raise NotImplementedError(
                 "Not implemented with real-space encoder. Use phase-flipped images instead"
             )
-        log("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -333,12 +331,12 @@ def main(args):
         loss_accum += loss * B
 
         if batch_it % args.log_interval == 0:
-            log(
+            logger.info(
                 "# [{}/{} images] gen loss={:.4f}, kld={:.4f}, beta={:.4f}, loss={:.4f}".format(
                     batch_it, Nimg, gen_loss, kld, beta, loss
                 )
             )
-    log(
+    logger.info(
         "# =====> Average gen loss = {:.6}, KLD = {:.6f}, total loss = {:.6f}".format(
             gen_loss_accum / Nimg, kld_accum / Nimg, loss_accum / Nimg
         )
@@ -360,11 +358,12 @@ def main(args):
             f,
         )
 
-    log("Finished in {}".format(dt.now() - t1))
+    logger.info("Finished in {}".format(dt.now() - t1))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -5,15 +5,13 @@ import argparse
 import os
 import pprint
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
-
 from cryodrgn import config, mrc, utils
 from cryodrgn.models import HetOnlyVAE
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -148,15 +146,15 @@ def main(args):
     if args.device is not None:
         use_cuda = torch.cuda.is_available()
         device = torch.device(f"cuda:{args.device}" if use_cuda else "cpu")
-        log("Use cuda device {}".format(args.device))
+        logger.info("Use cuda device {}".format(args.device))
         if not use_cuda:
-            log("WARNING: No GPUs used")
+            logger.warning("WARNING: No GPUs used")
     else:
         device = "cpu"
 
-    log(args)
+    logger.info(args)
     cfg = config.overwrite_config(args.config, args)
-    log("Loaded configuration:")
+    logger.info("Loaded configuration:")
     pprint.pprint(cfg)
 
     D = cfg["lattice_args"]["D"]  # image size + 1
@@ -188,9 +186,9 @@ def main(args):
         if not os.path.exists(args.o):
             os.makedirs(args.o)
 
-        log(f"Generating {len(z)} volumes")
+        logger.info(f"Generating {len(z)} volumes")
         for i, zz in enumerate(z, start=args.vol_start_index):
-            log(zz)
+            logger.info(zz)
             if args.downsample:
                 extent = lattice.extent * (args.downsample / (D - 1))
                 decoder = model.decoder
@@ -215,7 +213,7 @@ def main(args):
     # Single z
     else:
         z = np.array(args.z)
-        log(z)
+        logger.info(z)
         if args.downsample:
             extent = lattice.extent * (args.downsample / (D - 1))
             vol = model.decoder.eval_volume(
@@ -236,11 +234,12 @@ def main(args):
         mrc.write(args.o, vol.astype(np.float32), Apix=args.Apix)
 
     td = dt.now() - t1
-    log("Finished in {}".format(td))
+    logger.info("Finished in {}".format(td))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -139,6 +139,9 @@ def check_inputs(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     check_inputs(args)
     t1 = dt.now()
 
@@ -240,6 +243,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/parse_ctf_csparc.py
+++ b/cryodrgn/commands/parse_ctf_csparc.py
@@ -3,12 +3,11 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
+from cryodrgn import ctf
 
-from cryodrgn import ctf, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -32,7 +31,7 @@ def main(args):
 
     metadata = np.load(args.cs)
     N = len(metadata)
-    log("{} particles".format(N))
+    logger.info("{} particles".format(N))
 
     # sometimes blob/shape, blob/psize_A are missing from the .cs file
     try:
@@ -62,7 +61,7 @@ def main(args):
             ctf_params[:, i + 2] *= 180 / np.pi
 
     ctf.print_ctf_params(ctf_params[0])
-    log("Saving {}".format(args.o))
+    logger.info("Saving {}".format(args.o))
     with open(args.o, "wb") as f:
         pickle.dump(ctf_params.astype(np.float32), f)
     if args.png:
@@ -70,7 +69,7 @@ def main(args):
 
         ctf.plot_ctf(int(ctf_params[0, 0]), ctf_params[0, 1], ctf_params[0, 2:])
         plt.savefig(args.png)
-        log(args.png)
+        logger.info(args.png)
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands/parse_pose_csparc.py
+++ b/cryodrgn/commands/parse_pose_csparc.py
@@ -3,13 +3,12 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
 import torch
+from cryodrgn import lie_tools
 
-from cryodrgn import lie_tools, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -50,28 +49,28 @@ def main(args):
         TKEY = "alignments3D/shift"
 
     # parse rotations
-    log(f"Extracting rotations from {RKEY}")
+    logger.info(f"Extracting rotations from {RKEY}")
     rot = np.array([x[RKEY] for x in data])
     rot = torch.tensor(rot)
     rot = lie_tools.expmap(rot)
     rot = rot.numpy()
-    log("Transposing rotation matrix")
+    logger.info("Transposing rotation matrix")
     rot = np.array([x.T for x in rot])
-    log(rot.shape)
+    logger.info(rot.shape)
 
     # parse translations
-    log(f"Extracting translations from {TKEY}")
+    logger.info(f"Extracting translations from {TKEY}")
     trans = np.array([x[TKEY] for x in data])
     if args.hetrefine:
-        log("Scaling shifts by 2x")
+        logger.info("Scaling shifts by 2x")
         trans *= 2
-    log(trans.shape)
+    logger.info(trans.shape)
 
     # convert translations from pixels to fraction
     trans /= args.D
 
     # write output
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     with open(args.o, "wb") as f:
         pickle.dump((rot, trans), f)
 

--- a/cryodrgn/commands/parse_pose_star.py
+++ b/cryodrgn/commands/parse_pose_star.py
@@ -3,12 +3,11 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
-
 from cryodrgn import starfile, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -44,19 +43,19 @@ def main(args):
     assert args.D is not None, "Must provide image size with -D"
 
     N = len(s.df)
-    log(f"{N} particles")
+    logger.info(f"{N} particles")
 
     # parse rotations
     euler = np.zeros((N, 3))
     euler[:, 0] = s.df["_rlnAngleRot"]
     euler[:, 1] = s.df["_rlnAngleTilt"]
     euler[:, 2] = s.df["_rlnAnglePsi"]
-    log("Euler angles (Rot, Tilt, Psi):")
-    log(euler[0])
-    log("Converting to rotation matrix:")
+    logger.info("Euler angles (Rot, Tilt, Psi):")
+    logger.info(euler[0])
+    logger.info("Converting to rotation matrix:")
     rot = np.asarray([utils.R_from_relion(*x) for x in euler])
 
-    log(rot[0])
+    logger.info(rot[0])
 
     # parse translations
     trans = np.zeros((N, 2))
@@ -73,18 +72,18 @@ def main(args):
         trans[:, 1] = s.df["_rlnOriginYAngst"]
         trans /= args.Apix
     else:
-        log(
+        logger.warning(
             "Warning: Neither _rlnOriginX/Y nor _rlnOriginX/YAngst found. Defaulting to 0s."
         )
 
-    log("Translations (pixels):")
-    log(trans[0])
+    logger.info("Translations (pixels):")
+    logger.info(trans[0])
 
     # convert translations from pixels to fraction
     trans /= args.D
 
     # write output
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     with open(args.o, "wb") as f:
         pickle.dump((rot, trans), f)
 

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -350,6 +350,9 @@ def get_latest(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -563,6 +566,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import sys
 from datetime import datetime as dt
-
+import logging
 import numpy as np
 import torch
 import torch.nn as nn
@@ -26,8 +26,7 @@ from cryodrgn.lattice import Lattice
 from cryodrgn.pose import PoseTracker
 from cryodrgn.models import DataParallelDecoder, Decoder
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -335,18 +334,18 @@ def save_config(args, dataset, lattice, model, out_config):
         pickle.dump(meta, f)
 
 
-def get_latest(args, flog):
+def get_latest(args):
     # assumes args.num_epochs > latest checkpoint
-    flog("Detecting latest checkpoint...")
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     if args.do_pose_sgd:
         i = args.load.split(".")[-2]
         args.poses = f"{args.outdir}/pose.{i}.pkl"
         assert os.path.exists(args.poses)
-        flog(f"Loading {args.poses}")
+        logger.info(f"Loading {args.poses}")
     return args
 
 
@@ -354,15 +353,13 @@ def main(args):
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -371,13 +368,13 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        flog("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # load the particles
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
@@ -390,7 +387,6 @@ def main(args):
             window=args.window,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
     else:
         data = dataset.MRCData(
@@ -401,7 +397,6 @@ def main(args):
             window=args.window,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
     D = data.D
     Nimg = data.N
@@ -423,8 +418,8 @@ def main(args):
         feat_sigma=args.feat_sigma,
     )
     model.to(device)
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
@@ -435,7 +430,7 @@ def main(args):
 
     # load weights
     if args.load:
-        flog("Loading model weights from {}".format(args.load))
+        logger.info("Loading model weights from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -461,7 +456,7 @@ def main(args):
 
     # load CTF
     if args.ctf is not None:
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -493,12 +488,12 @@ def main(args):
 
     # parallelize
     if args.multigpu and torch.cuda.device_count() > 1:
-        flog(f"Using {torch.cuda.device_count()} GPUs!")
+        logger.info(f"Using {torch.cuda.device_count()} GPUs!")
         args.batch_size *= torch.cuda.device_count()
-        flog(f"Increasing batch size to {args.batch_size}")
+        logger.info(f"Increasing batch size to {args.batch_size}")
         model = DataParallelDecoder(model)
     elif args.multigpu:
-        flog(
+        logger.info(
             f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
         )
 
@@ -531,12 +526,12 @@ def main(args):
                 pose_optimizer.step()
             loss_accum += loss_item * len(ind)
             if batch_it % args.log_interval == 0:
-                flog(
+                logger.info(
                     "# [Train Epoch: {}/{}] [{}/{} images] loss={:.6f}".format(
                         epoch + 1, args.num_epochs, batch_it, Nimg, loss_item
                     )
                 )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average loss = {:.6}; Finished in {}".format(
                 epoch + 1, loss_accum / Nimg, dt.now() - t2
             )
@@ -560,7 +555,7 @@ def main(args):
         posetracker.save(out_pose)
 
     td = dt.now() - t1
-    flog(
+    logger.info(
         "Finished in {} ({} per epoch)".format(td, td / (args.num_epochs - start_epoch))
     )
 
@@ -568,5 +563,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -554,6 +554,9 @@ def get_latest(args):
 
 
 def main(args):
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
@@ -919,6 +922,4 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import pickle
 import sys
+import logging
 from datetime import datetime as dt
 import numpy as np
 import torch
@@ -25,8 +26,7 @@ from cryodrgn.lattice import Lattice
 from cryodrgn.models import HetOnlyVAE, unparallelize
 from cryodrgn.pose import PoseTracker
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -538,18 +538,18 @@ def save_config(args, dataset, lattice, model, out_config):
         pickle.dump(meta, f)
 
 
-def get_latest(args, flog):
+def get_latest(args):
     # assumes args.num_epochs > latest checkpoint
-    flog("Detecting latest checkpoint...")
+    logger.info("Detecting latest checkpoint...")
     weights = [f"{args.outdir}/weights.{i}.pkl" for i in range(args.num_epochs)]
     weights = [f for f in weights if os.path.exists(f)]
     args.load = weights[-1]
-    flog(f"Loading {args.load}")
+    logger.info(f"Loading {args.load}")
     if args.do_pose_sgd:
         i = args.load.split(".")[-2]
         args.poses = f"{args.outdir}/pose.{i}.pkl"
         assert os.path.exists(args.poses)
-        flog(f"Loading {args.poses}")
+        logger.info(f"Loading {args.poses}")
     return args
 
 
@@ -557,15 +557,13 @@ def main(args):
     t1 = dt.now()
     if args.outdir is not None and not os.path.exists(args.outdir):
         os.makedirs(args.outdir)
-    LOG = f"{args.outdir}/run.log"
 
-    def flog(msg):  # HACK: switch to logging module
-        return utils.flog(msg, LOG)
+    logger.addHandler(logging.FileHandler(f"{args.outdir}/run.log"))
 
     if args.load == "latest":
-        args = get_latest(args, flog)
-    flog(" ".join(sys.argv))
-    flog(args)
+        args = get_latest(args)
+    logger.info(" ".join(sys.argv))
+    logger.info(args)
 
     # set the random seed
     np.random.seed(args.seed)
@@ -574,9 +572,9 @@ def main(args):
     # set the device
     use_cuda = torch.cuda.is_available()
     device = torch.device("cuda" if use_cuda else "cpu")
-    flog("Use cuda {}".format(use_cuda))
+    logger.info("Use cuda {}".format(use_cuda))
     if not use_cuda:
-        log("WARNING: No GPUs detected")
+        logger.warning("WARNING: No GPUs detected")
 
     # set beta schedule
     if args.beta is None:
@@ -591,13 +589,13 @@ def main(args):
 
     # load index filter
     if args.ind is not None:
-        flog("Filtering image dataset with {}".format(args.ind))
+        logger.info("Filtering image dataset with {}".format(args.ind))
         ind = pickle.load(open(args.ind, "rb"))
     else:
         ind = None
 
     # load dataset
-    flog(f"Loading dataset from {args.particles}")
+    logger.info(f"Loading dataset from {args.particles}")
     if args.tilt is None:
         tilt = None
         args.use_real = args.encode_mode == "conv"  # Must be False
@@ -612,14 +610,13 @@ def main(args):
                 window=args.window,
                 datadir=args.datadir,
                 window_r=args.window_r,
-                flog=flog,
             )
         elif args.preprocessed:
-            flog(
+            logger.info(
                 "Using preprocessed inputs. Ignoring any --window/--invert-data options"
             )
             data = dataset.PreprocessedMRCData(
-                args.particles, norm=args.norm, ind=ind, flog=flog, lazy=args.lazy
+                args.particles, norm=args.norm, ind=ind, lazy=args.lazy
             )
         else:
             data = dataset.MRCData(
@@ -632,7 +629,6 @@ def main(args):
                 datadir=args.datadir,
                 max_threads=args.max_threads,
                 window_r=args.window_r,
-                flog=flog,
             )
 
     # Tilt series data -- lots of unsupported features
@@ -652,7 +648,6 @@ def main(args):
             keepreal=args.use_real,
             datadir=args.datadir,
             window_r=args.window_r,
-            flog=flog,
         )
         tilt = torch.tensor(utils.xrot(args.tilt_deg).astype(np.float32), device=device)
     Nimg = data.N
@@ -683,7 +678,7 @@ def main(args):
             raise NotImplementedError(
                 "Not implemented with real-space encoder. Use phase-flipped images instead"
             )
-        flog("Loading ctf params from {}".format(args.ctf))
+        logger.info("Loading ctf params from {}".format(args.ctf))
         ctf_params = ctf.load_ctf_for_training(D - 1, args.ctf)
         if args.ind is not None:
             ctf_params = ctf_params[ind]
@@ -725,18 +720,18 @@ def main(args):
         feat_sigma=args.feat_sigma,
     )
     model.to(device)
-    flog(model)
-    flog(
+    logger.info(model)
+    logger.info(
         "{} parameters in model".format(
             sum(p.numel() for p in model.parameters() if p.requires_grad)
         )
     )
-    flog(
+    logger.info(
         "{} parameters in encoder".format(
             sum(p.numel() for p in model.encoder.parameters() if p.requires_grad)
         )
     )
-    flog(
+    logger.info(
         "{} parameters in decoder".format(
             sum(p.numel() for p in model.decoder.parameters() if p.requires_grad)
         )
@@ -763,11 +758,11 @@ def main(args):
         ), "Encoder hidden layer dimension must be divisible by 8 for AMP training"
         # Also check zdim, enc_mask dim? Add them as warnings for now.
         if args.zdim % 8 != 0:
-            log(
+            logger.warning(
                 "Warning: z dimension is not a multiple of 8 -- AMP training speedup is not optimized"
             )
         if in_dim % 8 != 0:
-            log(
+            logger.warning(
                 "Warning: Masked input image dimension is not a mutiple of 8 -- AMP training speedup is not optimized"
             )
         try:  # Mixed precision with apex.amp
@@ -778,7 +773,7 @@ def main(args):
 
     # restart from checkpoint
     if args.load:
-        flog("Loading checkpoint from {}".format(args.load))
+        logger.info("Loading checkpoint from {}".format(args.load))
         checkpoint = torch.load(args.load)
         model.load_state_dict(checkpoint["model_state_dict"])
         optim.load_state_dict(checkpoint["optimizer_state_dict"])
@@ -790,15 +785,15 @@ def main(args):
     # parallelize
     num_workers_per_gpu = args.num_workers_per_gpu
     if args.multigpu and torch.cuda.device_count() > 1:
-        log(f"Using {torch.cuda.device_count()} GPUs!")
+        logger.info(f"Using {torch.cuda.device_count()} GPUs!")
         args.batch_size *= torch.cuda.device_count()
         cpu_count = os.cpu_count() or 1
         if num_workers_per_gpu * torch.cuda.device_count() > cpu_count:
             num_workers_per_gpu = max(1, cpu_count // torch.cuda.device_count())
-        log(f"Increasing batch size to {args.batch_size}")
+        logger.info(f"Increasing batch size to {args.batch_size}")
         model = DataParallel(model)
     elif args.multigpu:
-        log(
+        logger.warning(
             f"WARNING: --multigpu selected, but {torch.cuda.device_count()} GPUs detected"
         )
 
@@ -857,13 +852,13 @@ def main(args):
             loss_accum += loss * B
 
             if batch_it % args.log_interval == 0:
-                log(
+                logger.info(
                     "# [Train Epoch: {}/{}] [{}/{} images] gen loss={:.6f}, kld={:.6f}, beta={:.6f}, "
                     "loss={:.6f}".format(
                         epoch + 1, num_epochs, batch_it, Nimg, gen_loss, kld, beta, loss
                     )
                 )
-        flog(
+        logger.info(
             "# =====> Epoch: {} Average gen loss = {:.6}, KLD = {:.6f}, total loss = {:.6f}; Finished in {}".format(
                 epoch + 1,
                 gen_loss_accum / Nimg,
@@ -916,11 +911,14 @@ def main(args):
         out_pose = "{}/pose.pkl".format(args.outdir)
         posetracker.save(out_pose)
     td = dt.now() - t1
-    flog("Finished in {} ({} per epoch)".format(td, td / (num_epochs - start_epoch)))
+    logger.info(
+        "Finished in {} ({} per epoch)".format(td, td / (num_epochs - start_epoch))
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     args = add_args(parser).parse_args()
-    utils._verbose = args.verbose
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     main(args)

--- a/cryodrgn/commands/view_config.py
+++ b/cryodrgn/commands/view_config.py
@@ -6,10 +6,9 @@ import argparse
 import os
 import pickle
 from pprint import pprint
+import logging
 
-from cryodrgn import utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -24,13 +23,13 @@ def main(args):
     cfg = pickle.load(f)
     try:
         meta = pickle.load(f)
-        log(f'Version: {meta["version"]}')
-        log(f'Creation time: {meta["time"]}')
-        log("Command:")
+        logger.info(f'Version: {meta["version"]}')
+        logger.info(f'Creation time: {meta["time"]}')
+        logger.info("Command:")
         print(" ".join(meta["cmd"]))
     except:  # noqa: E722
         pass
-    log("Config:")
+    logger.info("Config:")
     pprint(cfg)
 
 

--- a/cryodrgn/commands_utils/add_psize.py
+++ b/cryodrgn/commands_utils/add_psize.py
@@ -1,10 +1,11 @@
 """Add pixel size to header of .mrc file"""
 
 import argparse
+import logging
 import numpy as np
-from cryodrgn import mrc, utils
+from cryodrgn import mrc
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -23,7 +24,7 @@ def main(args):
     assert isinstance(x, np.ndarray)
     h.update_apix(args.Apix)
     mrc.write(args.o, x, header=h)
-    log(f"Wrote {args.o}")
+    logger.info(f"Wrote {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/concat_pkls.py
+++ b/cryodrgn/commands_utils/concat_pkls.py
@@ -2,10 +2,10 @@
 
 import argparse
 import pickle
-
+import logging
 import numpy as np
 
-log = print
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -21,14 +21,14 @@ def main(args):
         t = [xx[1] for xx in x]
         r2 = np.concatenate(r)
         t2 = np.concatenate(t)
-        log(r2.shape)
-        log(t2.shape)
+        logger.info(r2.shape)
+        logger.info(t2.shape)
         x2 = (r2, t2)
     else:
         for i in x:
-            log(i.shape)
+            logger.info(i.shape)
         x2 = np.concatenate(x)
-        log(x2.shape)
+        logger.info(x2.shape)
     pickle.dump(x2, open(args.o, "wb"))
 
 

--- a/cryodrgn/commands_utils/filter_mrcs.py
+++ b/cryodrgn/commands_utils/filter_mrcs.py
@@ -1,12 +1,11 @@
 """Filter a particle stack"""
 
 import argparse
-
+import logging
 import numpy as np
-
 from cryodrgn import dataset, mrc, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -18,10 +17,10 @@ def add_args(parser):
 
 def main(args):
     x = dataset.load_particles(args.input, lazy=True)
-    log(f"Loaded {len(x)} particles")
+    logger.info(f"Loaded {len(x)} particles")
     ind = utils.load_pkl(args.ind)
     x = np.array([x[i].get() for i in ind])
-    log(f"New dimensions: {x.shape}")
+    logger.info(f"New dimensions: {x.shape}")
     mrc.write(args.o, x)
 
 

--- a/cryodrgn/commands_utils/filter_pkl.py
+++ b/cryodrgn/commands_utils/filter_pkl.py
@@ -3,10 +3,10 @@
 import argparse
 import os
 import pickle
-
+import logging
 import numpy as np
 
-log = print
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -34,18 +34,18 @@ def main(args):
 
     # pose.pkl contains a tuple of rotations and translations
     if type(x) == tuple:
-        log("Detected pose.pkl")
-        log(f"Old shape: {[xx.shape for xx in x]}")
+        logger.info("Detected pose.pkl")
+        logger.info(f"Old shape: {[xx.shape for xx in x]}")
         x = (xx[ind] for xx in x)
         x = tuple(x)
-        log(f"New shape: {[xx.shape for xx in x]}")
+        logger.info(f"New shape: {[xx.shape for xx in x]}")
 
     # all other cryodrgn pkls
     else:
-        log(f"Old shape: {x.shape}")
+        logger.info(f"Old shape: {x.shape}")
         x = x[ind]
-        log(f"New shape: {x.shape}")
-    log(f"Saving {args.o}")
+        logger.info(f"New shape: {x.shape}")
+    logger.info(f"Saving {args.o}")
     pickle.dump(x, open(args.o, "wb"))
 
 

--- a/cryodrgn/commands_utils/filter_star.py
+++ b/cryodrgn/commands_utils/filter_star.py
@@ -5,11 +5,10 @@ Filter a .star file
 import argparse
 import os
 import warnings
-
-from cryodrgn import utils
+import logging
 from cryodrgn.commands_utils import write_star
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -22,7 +21,7 @@ def add_args(parser):
 def main(args):
     warning_msg = "cryodrgn_utils filter_star is deprecated. Please use cryodrgn_utils write_star instead."
     warnings.warn(warning_msg, DeprecationWarning)
-    log(f"WARNING: {warning_msg}")
+    logger.warning(f"WARNING: {warning_msg}")
 
     args = write_star.add_args(argparse.ArgumentParser()).parse_args(
         [

--- a/cryodrgn/commands_utils/flip_hand.py
+++ b/cryodrgn/commands_utils/flip_hand.py
@@ -1,10 +1,11 @@
 """Flip handedness of an .mrc file"""
 
 import argparse
+import logging
 import numpy as np
-from cryodrgn import mrc, utils
+from cryodrgn import mrc
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -20,7 +21,7 @@ def main(args):
     assert isinstance(x, np.ndarray)
     x = x[::-1]
     mrc.write(args.o, x, header=h)
-    log(f"Wrote {args.o}")
+    logger.info(f"Wrote {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/invert_contrast.py
+++ b/cryodrgn/commands_utils/invert_contrast.py
@@ -1,10 +1,11 @@
 """Invert the contrast of an .mrc file"""
 
 import argparse
+import logging
 import numpy as np
-from cryodrgn import mrc, utils
+from cryodrgn import mrc
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -20,7 +21,7 @@ def main(args):
     assert isinstance(x, np.ndarray)
     x *= -1
     mrc.write(args.o, x, header=h)
-    log(f"Wrote {args.o}")
+    logger.info(f"Wrote {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/phase_flip.py
+++ b/cryodrgn/commands_utils/phase_flip.py
@@ -2,12 +2,11 @@
 
 import argparse
 import os
-
+import logging
 import numpy as np
+from cryodrgn import ctf, dataset, fft, mrc
 
-from cryodrgn import ctf, dataset, fft, mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -36,7 +35,7 @@ def main(args):
     imgs_flip = np.empty((len(imgs), D, D), dtype=np.float32)
     for i in range(len(imgs)):
         if i % 1000 == 0:
-            log(f"Processing image {i}")
+            logger.info(f"Processing image {i}")
         c = ctf.compute_ctf_np(freqs / ctf_params[i, 0], *ctf_params[i, 1:])
         c = c.reshape((D, D))
         ff = fft.fft2_center(imgs[i].get())
@@ -44,7 +43,7 @@ def main(args):
         img = fft.ifftn_center(ff)
         imgs_flip[i] = img.astype(np.float32)
 
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     mrc.write(args.o, imgs_flip)
 
 

--- a/cryodrgn/commands_utils/select_clusters.py
+++ b/cryodrgn/commands_utils/select_clusters.py
@@ -2,10 +2,10 @@
 
 import argparse
 import os
-
+import logging
 from cryodrgn import analysis, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -27,19 +27,19 @@ def add_args(parser):
 
 def main(args):
     labels = utils.load_pkl(args.labels)
-    log(f"{len(labels)} particles")
-    log(f"Selecting clusters {args.sel}")
+    logger.info(f"{len(labels)} particles")
+    logger.info(f"Selecting clusters {args.sel}")
     ind = analysis.get_ind_for_cluster(labels, args.sel)
-    log(f"Selected {len(ind)} particles")
-    log(ind)
+    logger.info(f"Selected {len(ind)} particles")
+    logger.info(ind)
     if args.parent_ind is not None:
-        log("Converting to original indices")
+        logger.info("Converting to original indices")
         parent_ind = utils.load_pkl(args.parent_ind)
         assert args.N_orig
         ind = analysis.convert_original_indices(ind, args.N_orig, parent_ind)
-        log(ind)
+        logger.info(ind)
     utils.save_pkl(ind, args.o)
-    log(f"Saved {args.o}")
+    logger.info(f"Saved {args.o}")
 
 
 if __name__ == "__main__":

--- a/cryodrgn/commands_utils/translate_mrcs.py
+++ b/cryodrgn/commands_utils/translate_mrcs.py
@@ -2,13 +2,12 @@
 
 import argparse
 import os
-
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
-
 from cryodrgn import dataset, fft, mrc, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -43,7 +42,7 @@ def main(args):
     # load particles
     particles = dataset.load_particles(args.mrcs, datadir=args.datadir)
     assert isinstance(particles, np.ndarray)
-    log(particles.shape)
+    logger.info(particles.shape)
     Nimg, D, D = particles.shape
 
     trans = utils.load_pkl(args.trans)
@@ -62,14 +61,14 @@ def main(args):
     imgs = np.empty((Nimg, D, D), dtype=np.float32)
     for ii in range(Nimg):
         if ii % 1000 == 0:
-            log(f"Processing image {ii}")
+            logger.info(f"Processing image {ii}")
         ff = fft.fft2_center(particles[ii])
         tfilt = np.dot(TCOORD, trans[ii]) * -2 * np.pi
         tfilt = np.cos(tfilt) + np.sin(tfilt) * 1j
         ff *= tfilt
         imgs[ii] = fft.ifftn_center(ff).astype(np.float32)
 
-    log(f"Writing {args.o}")
+    logger.info(f"Writing {args.o}")
     mrc.write(args.o, imgs)
 
     if args.out_png:

--- a/cryodrgn/commands_utils/view_header.py
+++ b/cryodrgn/commands_utils/view_header.py
@@ -2,10 +2,10 @@
 
 import argparse
 from pprint import pprint
+import logging
+from cryodrgn import mrc
 
-from cryodrgn import mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -15,7 +15,7 @@ def add_args(parser):
 
 def main(args):
     if not (args.input.endswith(".mrc") or args.input.endswith(".mrcs")):
-        log(f"Warning: {args.input} does not appear to be a .mrc(s) file")
+        logger.warning(f"Warning: {args.input} does not appear to be a .mrc(s) file")
     header = mrc.parse_header(args.input)
     pprint(header.fields)
     pprint(header.extended_header)

--- a/cryodrgn/commands_utils/view_mrcs.py
+++ b/cryodrgn/commands_utils/view_mrcs.py
@@ -1,12 +1,11 @@
 """View the first 9 images in a particle stack"""
 
 import argparse
-
+import logging
 import matplotlib.pyplot as plt
+from cryodrgn import analysis, mrc
 
-from cryodrgn import analysis, mrc, utils
-
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -18,14 +17,14 @@ def add_args(parser):
 
 def main(args):
     stack, _ = mrc.parse_mrc(args.input, lazy=True)
-    log("{} {}x{} images".format(len(stack), *stack[0].get().shape))
+    logger.info("{} {}x{} images".format(len(stack), *stack[0].get().shape))
     stack = [stack[x].get() for x in range(9)]
     if args.invert:
         stack = [-1 * x for x in stack]
     analysis.plot_projections(stack)
     if args.o:
         plt.savefig(args.o)
-        log(f"Wrote {args.o}")
+        logger.info(f"Wrote {args.o}")
     else:
         plt.show()
 

--- a/cryodrgn/commands_utils/write_cs.py
+++ b/cryodrgn/commands_utils/write_cs.py
@@ -5,9 +5,10 @@ Create a CryoSparc .cs file from a particle stack and ctf parameters, or an inpu
 import argparse
 import os
 import numpy as np
+import logging
 from cryodrgn import dataset, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -59,11 +60,11 @@ def main(args):
             assert len(particles) == len(
                 poses[0]
             ), f"{len(particles)} != {len(poses)}, Number of particles != number of poses"
-    log(f"{len(particles)} particles in {args.particles}")
+    logger.info(f"{len(particles)} particles in {args.particles}")
 
     if args.ind:
         ind = utils.load_pkl(args.ind)
-        log(f"Filtering to {len(ind)} particles")
+        logger.info(f"Filtering to {len(ind)} particles")
         particles = np.array(particles)[ind]
 
     if input_ext == ".cs":

--- a/cryodrgn/commands_utils/write_star.py
+++ b/cryodrgn/commands_utils/write_star.py
@@ -6,10 +6,12 @@ import argparse
 import os
 import numpy as np
 import pandas as pd
+import logging
 from cryodrgn import dataset, mrc, utils
 from cryodrgn.starfile import Starfile
 
-log = utils.log
+logger = logging.getLogger(__name__)
+
 
 CTF_HEADERS = [
     "_rlnDefocusU",
@@ -99,7 +101,7 @@ def main(args):
             assert len(particles) == len(
                 poses[0]
             ), f"{len(particles)} != {len(poses)}, Number of particles != number of poses"
-    log(f"{len(particles)} particles in {args.particles}")
+    logger.info(f"{len(particles)} particles in {args.particles}")
 
     if input_ext == ".star":
         particle_ind = np.arange(len(particles))
@@ -113,7 +115,7 @@ def main(args):
 
     if args.ind:
         ind = utils.load_pkl(args.ind)
-        log(f"Filtering to {len(ind)} particles")
+        logger.info(f"Filtering to {len(ind)} particles")
         particles = [particles[ii] for ii in ind]
         if ctf is not None:
             ctf = ctf[ind]

--- a/cryodrgn/ctf.py
+++ b/cryodrgn/ctf.py
@@ -2,10 +2,10 @@ from typing import Union, Optional
 import numpy as np
 import seaborn as sns
 import torch
-
+import logging
 from cryodrgn import utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 def compute_ctf(
@@ -107,15 +107,15 @@ def compute_ctf_np(
 
 def print_ctf_params(params: np.ndarray) -> None:
     assert len(params) == 9
-    log("Image size (pix)  : {}".format(int(params[0])))
-    log("A/pix             : {}".format(params[1]))
-    log("DefocusU (A)      : {}".format(params[2]))
-    log("DefocusV (A)      : {}".format(params[3]))
-    log("Dfang (deg)       : {}".format(params[4]))
-    log("voltage (kV)      : {}".format(params[5]))
-    log("cs (mm)           : {}".format(params[6]))
-    log("w                 : {}".format(params[7]))
-    log("Phase shift (deg) : {}".format(params[8]))
+    logger.info("Image size (pix)  : {}".format(int(params[0])))
+    logger.info("A/pix             : {}".format(params[1]))
+    logger.info("DefocusU (A)      : {}".format(params[2]))
+    logger.info("DefocusV (A)      : {}".format(params[3]))
+    logger.info("Dfang (deg)       : {}".format(params[4]))
+    logger.info("voltage (kV)      : {}".format(params[5]))
+    logger.info("cs (mm)           : {}".format(params[6]))
+    logger.info("w                 : {}".format(params[7]))
+    logger.info("Phase shift (deg) : {}".format(params[8]))
 
 
 def plot_ctf(D: int, Apix: float, ctf_params: np.ndarray) -> None:

--- a/cryodrgn/lattice.py
+++ b/cryodrgn/lattice.py
@@ -4,11 +4,10 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-
+import logging
 from cryodrgn import utils
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 class Lattice:
@@ -67,7 +66,7 @@ class Lattice:
         assert (
             2 * L + 1 <= self.D
         ), "Mask with size {} too large for lattice with size {}".format(L, self.D)
-        log("Using square lattice of size {}x{}".format(2 * L + 1, 2 * L + 1))
+        logger.info("Using square lattice of size {}x{}".format(2 * L + 1, 2 * L + 1))
         b, e = self.D2 - L, self.D2 + L
         c1 = self.coords.view(self.D, self.D, 3)[b, b]
         c2 = self.coords.view(self.D, self.D, 3)[e, e]
@@ -88,7 +87,7 @@ class Lattice:
         assert (
             2 * R + 1 <= self.D
         ), "Mask with radius {} too large for lattice with size {}".format(R, self.D)
-        vlog("Using circular lattice with radius {}".format(R))
+        logger.debug("Using circular lattice with radius {}".format(R))
 
         r = R / (self.D // 2) * self.extent
         mask = self.coords.pow(2).sum(-1) <= r**2

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -12,7 +12,6 @@ import cryodrgn.types as types
 from cryodrgn import fft, lie_tools, utils
 from cryodrgn.lattice import Lattice
 
-log = utils.log
 Norm = Sequence[Any]  # mean, std
 
 

--- a/cryodrgn/pose.py
+++ b/cryodrgn/pose.py
@@ -1,14 +1,13 @@
 import pickle
 from typing import Optional, Tuple, Union, List
-
+import logging
 import numpy as np
 import torch
 import torch.nn as nn
 from torch import Tensor
-
 from cryodrgn import lie_tools, utils
 
-log = utils.log
+logger = logging.getLogger(__name__)
 
 
 class PoseTracker(nn.Module):
@@ -111,7 +110,7 @@ class PoseTracker(nn.Module):
             ), "ERROR: Old pose format detected. Translations must be in units of fraction of box."
             trans *= D  # convert from fraction to pixels
         else:
-            log("WARNING: No translations provided")
+            logger.warning("WARNING: No translations provided")
             trans = None
 
         return cls(rots, trans, D, emb_type, device=device)

--- a/cryodrgn/pose_search.py
+++ b/cryodrgn/pose_search.py
@@ -1,14 +1,14 @@
+import logging
 import numpy as np
 import torch
 import torch.nn.functional as F
 from typing import Optional, Union, Tuple
-from cryodrgn import lie_tools, shift_grid, so3_grid, utils
+from cryodrgn import lie_tools, shift_grid, so3_grid
 from cryodrgn.models import unparallelize, HetOnlyVAE
 from cryodrgn.lattice import Lattice
 import torch.nn as nn
 
-log = utils.log
-vlog = utils.vlog
+logger = logging.getLogger(__name__)
 
 
 def rot_2d(angle: float, outD: int, device: torch.device) -> torch.Tensor:
@@ -148,7 +148,7 @@ class PoseSearch:
                 assert isinstance(_model, HetOnlyVAE)
                 x = _model.cat_z(x, z)
             x = x.to(device)
-            # log(f"Evaluating model on {x.shape} = {x.nelement() // 3} points")
+            # logger.info(f"Evaluating model on {x.shape} = {x.nelement() // 3} points")
             with torch.no_grad():
                 y_hat = self.model(x)
                 y_hat = y_hat.float()

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -2,34 +2,11 @@ from collections.abc import Hashable
 import functools
 import os
 import pickle
-import sys
-from datetime import datetime as dt
+import logging
 from typing import Tuple
 import numpy as np
 
-_verbose = False
-
-
-def log(msg: object) -> None:
-    print("{}     {}".format(dt.now().strftime("%Y-%m-%d %H:%M:%S.%f"), msg))
-    sys.stdout.flush()
-
-
-def vlog(msg: str) -> None:
-    if _verbose:
-        print("{}     {}".format(dt.now().strftime("%Y-%m-%d %H:%M:%S"), msg))
-        sys.stdout.flush()
-
-
-def flog(msg: str, outfile: str) -> None:
-    msg = "{}     {}".format(dt.now().strftime("%Y-%m-%d %H:%M:%S"), msg)
-    print(msg)
-    sys.stdout.flush()
-    try:
-        with open(outfile, "a") as f:
-            f.write(msg + "\n")
-    except Exception as e:
-        log(e)
+logger = logging.getLogger(__name__)
 
 
 class memoized(object):
@@ -71,7 +48,7 @@ def load_pkl(pkl: str):
 
 def save_pkl(data, out_pkl: str, mode: str = "wb") -> None:
     if mode == "wb" and os.path.exists(out_pkl):
-        vlog(f"Warning: {out_pkl} already exists. Overwriting.")
+        logger.warning(f"Warning: {out_pkl} already exists. Overwriting.")
     with open(out_pkl, mode) as f:
         pickle.dump(data, f)
 
@@ -182,7 +159,7 @@ def zero_sphere(vol: np.ndarray) -> np.ndarray:
     assert len(set(vol.shape)) == 1, "volume must be a cube"
     D = vol.shape[0]
     tmp = _zero_sphere_helper(D)
-    vlog("Zeroing {} pixels".format(len(tmp[0])))
+    logger.info("Zeroing {} pixels".format(len(tmp[0])))
     vol[tmp] = 0
     return vol
 

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -159,7 +159,7 @@ def zero_sphere(vol: np.ndarray) -> np.ndarray:
     assert len(set(vol.shape)) == 1, "volume must be a cube"
     D = vol.shape[0]
     tmp = _zero_sphere_helper(D)
-    logger.info("Zeroing {} pixels".format(len(tmp[0])))
+    logger.debug("Zeroing {} pixels".format(len(tmp[0])))
     vol[tmp] = 0
     return vol
 


### PR DESCRIPTION
Switched to using the `logging` module, as per issue #204.

- A `logger` is obtained by `__name__` whenever needed. This causes the logging configuration at the top of the `cryodrgn` module (in `__init__.py`) to take effect.
- Bare `log()` calls are interpreted to mean that we want to emit `INFO` messages, so they are replaced by `logger.info()`.
- Where `log("WARNING:..")` was seen, its replaced by `logger.warn()`
- A `flog()` call used to, in turn, pass on the log filename to lots of calls. This is now replaced by a `logger.addHandler(logging.FileHandler(<path>))`, with the rest of the code simply sticking to the standard `logger.info`/`logger.warn` etc.
- We used to set the `_verbose` boolean in `utils.py` and then use `vlog()` calls. This is simplified to now set the logging level to `DEBUG` instead:
  ```
        if args.verbose:
          logger.setLevel(logging.DEBUG)
  ```
  
Code works as expected when I look at `stdout`, and also when looking at the appropriate log files if applicable.