### PR TITLE
Fix in-place division of poses in checkpoint

### DIFF
--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -614,8 +614,7 @@ def save_checkpoint(
             D = _model.lattice.D
         else:
             D = model.lattice.D
-        trans /= D
-        pickle.dump((rot, trans), f)
+        pickle.dump((rot, trans / D), f)
 
 
 def save_config(args, dataset, lattice, model, out_config):

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -286,8 +286,7 @@ def save_checkpoint(
     with open(out_poses, "wb") as f:
         rot, trans = pose
         # When saving translations, save in box units (fractional)
-        trans /= model.D
-        pickle.dump((rot, trans), f)
+        pickle.dump((rot, trans / model.D), f)
 
 
 def pretrain(model, lattice, optim, batch, tilt=None):


### PR DESCRIPTION
`save_checkpoint` has an in-place modification to `trans` which was messing up the cached poses between epochs. Subtle bug... should the function contract be "don't modify your arguments" or "copy all tensors before passing into a function"? I think the former.

Introduced in https://github.com/zhonge/cryodrgn/commit/6ae18690a9ab600cc1c4ac6b21bafa4989c70afe

Fixes https://github.com/zhonge/cryodrgn/issues/225 

(Results not visualized - @zhonge please check this fixes the bug).