### PR TITLE
Release workflow fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - '*'
 
 jobs:
-  run_tests:
+  release:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     branches: [ master ]
-  tags:
-    - '*'
+    tags:
+      - '*'
 
 jobs:
   run_tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  tags:
+    - '*'
 
 jobs:
   run_tests:


### PR DESCRIPTION
Release action was initially not set to trigger on a tag push, only a regular push. Please "squash and merge".