### PR TITLE
Flake8 enabled and fixes applied

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-select = B950
 extend-ignore = E203,E501
 max-complexity = 99
 max-line-length = 88

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -497,8 +497,8 @@ def train(
 
     if use_tilt:
         gen_loss = 0.5 * F.mse_loss(gen_slice(rot), y) + 0.5 * F.mse_loss(
-            gen_slice(bnb.tilt @ rot), yt  # type: ignore
-        )  # noqa: F821
+            gen_slice(bnb.tilt @ rot), yt  # type: ignore  # noqa: F821
+        )
     else:
         gen_loss = F.mse_loss(gen_slice(rot), y)
 

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -5,7 +5,6 @@ Homogeneous NN reconstruction with hierarchical pose optimization
 import argparse
 import os
 import pickle
-import signal
 import sys
 from datetime import datetime as dt
 import logging
@@ -20,14 +19,6 @@ from cryodrgn.lattice import Lattice
 from cryodrgn.pose_search import PoseSearch
 
 logger = logging.getLogger(__name__)
-
-# def debug_signal_handler(signal, frame):
-#     import pdb
-
-#     pdb.set_trace()
-
-
-# signal.signal(signal.SIGINT, debug_signal_handler)
 
 
 def add_args(parser):

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -8,7 +8,7 @@ from datetime import datetime as dt
 import logging
 import numpy as np
 import torch
-from cryodrgn import config, mrc, utils
+from cryodrgn import config, mrc
 from cryodrgn.models import HetOnlyVAE
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,6 @@ def main(args):
 
     # Multiple z
     if args.z_start or args.zfile:
-
         # Get z values
         if args.z_start:
             args.z_start = np.array(args.z_start)

--- a/cryodrgn/commands/parse_ctf_star.py
+++ b/cryodrgn/commands/parse_ctf_star.py
@@ -5,7 +5,7 @@ import os
 import pickle
 import logging
 import numpy as np
-from cryodrgn import ctf, starfile, utils
+from cryodrgn import ctf, starfile
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -10,7 +10,6 @@ import logging
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.nn.parallel import DataParallel
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
@@ -20,8 +19,7 @@ except ImportError:
     pass
 
 import cryodrgn
-import cryodrgn.types as types
-from cryodrgn import ctf, dataset, models, mrc, utils
+from cryodrgn import ctf, dataset, models, mrc
 from cryodrgn.lattice import Lattice
 from cryodrgn.pose import PoseTracker
 from cryodrgn.models import DataParallelDecoder, Decoder

--- a/cryodrgn/ctf.py
+++ b/cryodrgn/ctf.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Optional
 import numpy as np
 import seaborn as sns
 import torch

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -13,7 +13,7 @@ from multiprocessing import Pool
 import logging
 from torch.utils import data
 
-from cryodrgn import fft, mrc, starfile, utils
+from cryodrgn import fft, mrc, starfile
 
 
 logger = logging.getLogger(__name__)
@@ -219,8 +219,10 @@ class MRCData(data.Dataset):
         if keepreal:
             self.particles_real = particles_real  # noqa: F821
             logger.info(
-                "Normalized real space images by {}".format(particles_real.std())
-            )  # noqa: F821
+                "Normalized real space images by {}".format(
+                    particles_real.std()  # noqa: F821
+                )
+            )
             self.particles_real /= particles_real.std()  # noqa: F821
 
     def __len__(self):

--- a/cryodrgn/lattice.py
+++ b/cryodrgn/lattice.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 import logging
-from cryodrgn import utils
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -1,6 +1,6 @@
 """Pytorch models"""
 
-from typing import Optional, Tuple, Type, Union, Sequence, Any
+from typing import Optional, Tuple, Type, Sequence, Any
 import numpy as np
 import torch
 from torch import Tensor
@@ -8,7 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 from torch.nn.parallel import DataParallel
-import cryodrgn.types as types
 from cryodrgn import fft, lie_tools, utils
 from cryodrgn.lattice import Lattice
 

--- a/cryodrgn/pose_search.py
+++ b/cryodrgn/pose_search.py
@@ -68,7 +68,6 @@ class PoseSearch:
         t_yshift: int = 0,
         device: Optional[torch.device] = None,
     ):
-
         self.model = model
         self.lattice = lattice
         self.base_healpy = base_healpy
@@ -132,7 +131,6 @@ class PoseSearch:
             ctf_i = ctf_i.view(B, 1, 1, -1)[..., mask]  # Bx1x1xYX
 
         def compute_err(images, rot):
-
             adj_angles_inplane = None
             if angles_inplane is not None:
                 # apply a random in-plane rotation from the set


### PR DESCRIPTION
I realized that we weren't really using the full power of `flake8` (the `.flake8` file was disabling all checks except a single one!). I've enabled them all now (excluding a couple that are recommended to be ignored like we were doing before). Fortunately only a handful of files need tweaking to comply with flake8 - mostly to do with unused imports and blank lines.