### PR TITLE
Fix for issue #237

### DIFF
--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -232,6 +232,12 @@ class DataParallelDecoder(Decoder):
         assert isinstance(module, Decoder)
         return module.eval_volume(*args, **kwargs)
 
+    def forward(self, *args, **kwargs):
+        return self.dp.module.forward(*args, **kwargs)
+
+    def state_dict(self, *args, **kwargs):
+        return self.dp.module.state_dict(*args, **kwargs)
+
 
 class PositionalDecoder(Decoder):
     def __init__(

--- a/tests/test_abinit.py
+++ b/tests/test_abinit.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import os.path
-from cryodrgn.commands import abinit_het, abinit_homo, backproject_voxel
+from cryodrgn.commands import abinit_het, abinit_homo, analyze, backproject_voxel
 
 DATA_FOLDER = os.path.join(os.path.dirname(__file__), "..", "testing", "data")
 
@@ -51,6 +51,14 @@ def test_abinit_het_and_backproject():
             + abinit_args
         )
     )
+
+    args = analyze.add_args(argparse.ArgumentParser()).parse_args(
+        [
+            "output/abinit_het",
+            "29",  # Epoch number to analyze - 0-indexed
+        ]
+    )
+    analyze.main(args)
 
     args = backproject_voxel.add_args(argparse.ArgumentParser()).parse_args(
         [

--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -34,7 +34,7 @@ def test_run(mrcs_file, poses_file):
             "--lr",
             ".0001",
             "--num-epochs",
-            "20",
+            "3",
             "--seed",
             "0",
             "--poses",
@@ -43,14 +43,40 @@ def test_run(mrcs_file, poses_file):
             "10",
             "--pe-type",
             "gaussian",
+            "--multigpu",
         ]
     )
     train_vae.main(args)
 
+    # Load a check-pointed model and run for another epoch, this time without --multigpu
+    train_vae.main(
+        train_vae.add_args(argparse.ArgumentParser()).parse_args(
+            [
+                mrcs_file,
+                "-o",
+                "output",
+                "--lr",
+                ".0001",
+                "--num-epochs",
+                "4",
+                "--seed",
+                "0",
+                "--poses",
+                poses_file,
+                "--zdim",
+                "10",
+                "--pe-type",
+                "gaussian",
+                "--load",
+                "output/weights.2.pkl",
+            ]
+        )
+    )
+
     args = analyze.add_args(argparse.ArgumentParser()).parse_args(
         [
             "output",
-            "19",  # Epoch number to analyze - 0-indexed
+            "2",  # Epoch number to analyze - 0-indexed
             "--pc",
             "3",  # Number of principal component traversals to generate
             "--ksample",
@@ -61,11 +87,11 @@ def test_run(mrcs_file, poses_file):
     )
     analyze.main(args)
 
-    shutil.rmtree("output/landscape.19", ignore_errors=True)
+    shutil.rmtree("output/landscape.3", ignore_errors=True)
     args = analyze_landscape.add_args(argparse.ArgumentParser()).parse_args(
         [
             "output",
-            "19",  # Epoch number to analyze - 0-indexed
+            "2",  # Epoch number to analyze - 0-indexed
             "--sketch-size",
             "10",  # Number of volumes to generate for analysis
             "--downsample",
@@ -76,12 +102,12 @@ def test_run(mrcs_file, poses_file):
             "1",
         ]
     )
-    shutil.rmtree("output/landscape.19", ignore_errors=True)
+    shutil.rmtree("output/landscape.3", ignore_errors=True)
     analyze_landscape.main(args)
 
     args = graph_traversal.add_args(argparse.ArgumentParser()).parse_args(
         [
-            "output/z.19.pkl",
+            "output/z.3.pkl",
             "--anchors",
             "22",
             "49",
@@ -107,7 +133,7 @@ def test_run(mrcs_file, poses_file):
 
     args = eval_vol.add_args(argparse.ArgumentParser()).parse_args(
         [
-            "output/weights.19.pkl",
+            "output/weights.3.pkl",
             "--config",
             "output/config.pkl",
             "--zfile",

--- a/tests/test_train_nn.py
+++ b/tests/test_train_nn.py
@@ -1,0 +1,52 @@
+import os.path
+import argparse
+import pytest
+from cryodrgn.mrc import parse_mrc
+from cryodrgn.commands import train_nn
+
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), "..", "testing", "data")
+
+
+@pytest.fixture
+def mrcs_data():
+    return parse_mrc(f"{DATA_FOLDER}/toy_projections.mrcs", lazy=False)[0]
+
+
+@pytest.fixture
+def poses_file():
+    return f"{DATA_FOLDER}/toy_angles.pkl"
+
+
+def test_train_nn(mrcs_data, poses_file):
+    args = train_nn.add_args(argparse.ArgumentParser()).parse_args(
+        [
+            f"{DATA_FOLDER}/toy_projections.mrcs",
+            "--outdir",
+            "output/train_nn",
+            "--poses",
+            poses_file,
+            "--num-epochs",
+            "3",
+            "--no-amp",
+            "--multigpu",
+        ]
+    )
+    train_nn.main(args)
+
+    # Load a check-pointed model, this time with no --multigpu
+    train_nn.main(
+        train_nn.add_args(argparse.ArgumentParser()).parse_args(
+            [
+                f"{DATA_FOLDER}/toy_projections.mrcs",
+                "--outdir",
+                "output/train_nn",
+                "--poses",
+                poses_file,
+                "--num-epochs",
+                "5",
+                "--no-amp",
+                "--load",
+                "output/train_nn/weights.2.pkl",
+            ]
+        )
+    )


### PR DESCRIPTION
These changes address issue #237 at the place where it was reported (`abinit_het`+`analyze`) plus a couple of related places. I'll leave notes inline for review.

An earlier [PR](https://github.com/zhonge/cryodrgn/pull/190), was correct in its scope, but left open the possibility of a robust fix:
```
The fix here fixes these 2 issues, but means that a multi-gpu model has to be re-loaded again in a multi-gpu set up. This seems reasonable to me. A more robust solution would not have this restriction.
```

This PR fixes that issue, such that for `abinit_het`/`train_nn`/`train_vae` (the 3 places where one can specify `--multigpu`), saving the checkpoint saves only the state_dict of the underlying model. This allows one to mix `--multigpu` either before or after (or both, or none..) when saving/reloading a checkpoint, and continue training without errors. `train_vae` is already using this approach and is working correctly:
https://github.com/zhonge/cryodrgn/blob/4c1527a848736911033b02eb6753cb1481f13674/cryodrgn/commands/train_vae.py#L489

This fix also allows `HetOnlyVAE` to load the state_dictionary correctly in all situations, without making any changes there:
https://github.com/zhonge/cryodrgn/blob/4c1527a848736911033b02eb6753cb1481f13674/cryodrgn/models.py#L122

While adding more unit tests to exercise `train_nn` for a similar scenario, I noticed that `DataParallelDecoder` wasn't equipped to run the `forward` method, and was failing. I've added this method now. The tests verify that it works correctly.
