### PR TITLE
Vb/issue235 -- Convert config.pkl to config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Image poses may be *locally* refined using the `--do-pose-sgd` flag. Please cons
 
 ## 6. Analysis of results
 
-Once the model has finished training, the output directory will contain a configuration file `config.pkl`, neural network weights `weights.pkl`, image poses (if performing pose sgd) `pose.pkl`, and the latent embeddings for each image `z.pkl`. The latent embeddings are provided in the same order as the input particles. To analyze these results, use the `cryodrgn analyze` command to visualize the latent space and generate structures. `cryodrgn analyze` will also provide a template jupyter notebook for further interactive visualization and analysis.
+Once the model has finished training, the output directory will contain a configuration file `config.yaml`, neural network weights `weights.pkl`, image poses (if performing pose sgd) `pose.pkl`, and the latent embeddings for each image `z.pkl`. The latent embeddings are provided in the same order as the input particles. To analyze these results, use the `cryodrgn analyze` command to visualize the latent space and generate structures. `cryodrgn analyze` will also provide a template jupyter notebook for further interactive visualization and analysis.
 
 NEW in version 1.0: There are two additional tools `cryodrgn analyze_landscape` and `cryodrgn analyze_landscape_full` for more comprehensive and auomated analyses of cryodrgn results.
 
@@ -497,12 +497,11 @@ Additional structures may be generated using `cryodrgn eval_vol`:
 	  weights               Model weights
 
 	optional arguments:
-	  -h, --help            show this help message and exit
-	  -c PKL, --config PKL  CryoDRGN config.pkl file
-	  -o O                  Output .mrc or directory
-	  --prefix PREFIX       Prefix when writing out multiple .mrc files (default:
-	                        vol_)
-	  -v, --verbose         Increaes verbosity
+	  -h, --help             show this help message and exit
+	  -c YAML, --config YAML CryoDRGN config.yaml file
+	  -o O                   Output .mrc or directory
+	  --prefix PREFIX        Prefix when writing out multiple .mrc files (default: vol_)
+	  -v, --verbose          Increase verbosity
 
 	Specify z values:
 	  -z [Z [Z ...]]        Specify one z-value
@@ -519,7 +518,7 @@ Additional structures may be generated using `cryodrgn eval_vol`:
 	  -d DOWNSAMPLE, --downsample DOWNSAMPLE
 	                        Downsample volumes to this box size (pixels)
 
-	Overwrite architecture hyperparameters in config.pkl:
+	Overwrite architecture hyperparameters in config.yaml:
 	  --norm NORM NORM
 	  -D D                  Box size
 	  --enc-layers QLAYERS  Number of hidden layers
@@ -543,19 +542,19 @@ Additional structures may be generated using `cryodrgn eval_vol`:
 
 To generate a volume at a single value of the latent variable:
 
-    $ cryodrgn eval_vol [YOUR_WORKDIR]/weights.pkl --config [YOUR_WORKDIR]/config.pkl -z ZVALUE -o reconstruct.mrc
+    $ cryodrgn eval_vol [YOUR_WORKDIR]/weights.pkl --config [YOUR_WORKDIR]/config.yaml -z ZVALUE -o reconstruct.mrc
 
 The number of inputs for `-z` must match the dimension of your latent variable.
 
 Or to generate a trajectory of structures from a defined start and ending point, use the `--z-start` and `--z-end` arugments:
 
-    $ cryodrgn eval_vol [YOUR_WORKDIR]/weights.pkl --config [YOUR_WORKDIR]/config.pkl --z-start -3 --z-end 3 -n 20 -o [WORKDIR]/trajectory
+    $ cryodrgn eval_vol [YOUR_WORKDIR]/weights.pkl --config [YOUR_WORKDIR]/config.yaml --z-start -3 --z-end 3 -n 20 -o [WORKDIR]/trajectory
 
 This example generates 20 structures at evenly spaced values between z=[-3,3], assuming a 1-dimensional latent variable model.
 
 Finally, a series of structures can be generated using values of z given in a file specified by the arugment `--zfile`:
 
-    $ cryodrgn eval_vol [WORKDIR]/weights.pkl --config [WORKDIR]/config.pkl --zfile zvalues.txt -o [WORKDIR]/trajectory
+    $ cryodrgn eval_vol [WORKDIR]/weights.pkl --config [WORKDIR]/config.yaml --zfile zvalues.txt -o [WORKDIR]/trajectory
 
 The input to `--zfile` is expected to be an array of dimension (N_volumes x zdim), loaded with np.loadtxt.
 

--- a/cryodrgn/analysis.py
+++ b/cryodrgn/analysis.py
@@ -577,7 +577,7 @@ def gen_volumes(
     """Call cryodrgn eval_vol to generate volumes at specified z values
     Input:
         weights (str): Path to model weights .pkl
-        config (str): Path to config.pkl
+        config (str): Path to config.yaml
         zfile (str): Path to .txt file of z values
         outdir (str): Path to output directory for volumes,
         device (int or None): Specify cuda device

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -14,10 +14,9 @@ import torch.nn.functional as F
 from torch.nn.parallel import DataParallel
 from torch.utils.data import DataLoader
 from typing import Union
-import yaml
-import cryodrgn
 from cryodrgn import ctf, dataset, lie_tools, utils
 from cryodrgn.beta_schedule import LinearSchedule, get_beta_schedule
+import cryodrgn.config
 from cryodrgn.lattice import Lattice
 from cryodrgn.losses import EquivarianceLoss
 from cryodrgn.models import HetOnlyVAE, unparallelize
@@ -650,12 +649,8 @@ def save_config(args, dataset, lattice, model, out_config):
     config = dict(
         dataset_args=dataset_args, lattice_args=lattice_args, model_args=model_args
     )
-    config["seed"] = args.seed
-    config["version"] = cryodrgn.__version__
-    config["time"] = dt.now()
-    config["cmd"] = sys.argv
-    with open(out_config, "w") as f:
-        yaml.dump(config, f)
+
+    cryodrgn.config.save(config, out_config)
 
 
 def sort_poses(poses):

--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 from torch.nn.parallel import DataParallel
 from torch.utils.data import DataLoader
 from typing import Union
+import yaml
 import cryodrgn
 from cryodrgn import ctf, dataset, lie_tools, utils
 from cryodrgn.beta_schedule import LinearSchedule, get_beta_schedule
@@ -650,10 +651,11 @@ def save_config(args, dataset, lattice, model, out_config):
         dataset_args=dataset_args, lattice_args=lattice_args, model_args=model_args
     )
     config["seed"] = args.seed
-    with open(out_config, "wb") as f:
-        pickle.dump(config, f)
-        meta = dict(time=dt.now(), cmd=sys.argv, version=cryodrgn.__version__)
-        pickle.dump(meta, f)
+    config["version"] = cryodrgn.__version__
+    config["time"] = dt.now()
+    config["cmd"] = sys.argv
+    with open(out_config, "w") as f:
+        yaml.dump(config, f)
 
 
 def sort_poses(poses):
@@ -890,7 +892,7 @@ def main(args):
         pose_model = model
 
     # save configuration
-    out_config = "{}/config.pkl".format(args.outdir)
+    out_config = "{}/config.yaml".format(args.outdir)
     save_config(args, data, lattice, model, out_config)
 
     ps = PoseSearch(

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -348,7 +348,7 @@ def main(args):
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
-    config = f"{workdir}/config.pkl"
+    config = f"{workdir}/config.yaml"
     outdir = f"{workdir}/analyze.{E}"
     if E == -1:
         zfile = f"{workdir}/z.pkl"

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -4,6 +4,7 @@ Visualize latent space and generate volumes
 
 import argparse
 import os
+import os.path
 import shutil
 from datetime import datetime as dt
 import logging
@@ -348,7 +349,11 @@ def main(args):
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
-    config = f"{workdir}/config.yaml"
+    config = (
+        f"{workdir}/config.yaml"
+        if os.path.exists(f"{workdir}/config.yaml")
+        else f"{workdir}/config.pkl"
+    )
     outdir = f"{workdir}/analyze.{E}"
     if E == -1:
         zfile = f"{workdir}/z.pkl"

--- a/cryodrgn/commands/analyze_landscape.py
+++ b/cryodrgn/commands/analyze_landscape.py
@@ -450,7 +450,7 @@ def main(args):
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
-    config = f"{workdir}/config.pkl"
+    config = f"{workdir}/config.yaml"
     outdir = f"{workdir}/landscape.{E}"
 
     if args.outdir:
@@ -505,7 +505,7 @@ def main(args):
 
     logger.info("Analyzing volumes...")
     # get particle indices if the dataset was originally filtered
-    c = utils.load_pkl(config)
+    c = utils.load_config(config)
     particle_ind = (
         utils.load_pkl(c["dataset_args"]["ind"])
         if c["dataset_args"]["ind"] is not None

--- a/cryodrgn/commands/analyze_landscape.py
+++ b/cryodrgn/commands/analyze_landscape.py
@@ -4,6 +4,7 @@ Pipeline to analyze cryoDRGN volume distribution
 
 import argparse
 import os
+import os.path
 from collections import Counter
 from datetime import datetime as dt
 import logging
@@ -16,6 +17,7 @@ from scipy.ndimage.morphology import binary_dilation
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.decomposition import PCA
 from cryodrgn import analysis, mrc, utils
+import cryodrgn.config
 
 logger = logging.getLogger(__name__)
 
@@ -450,7 +452,11 @@ def main(args):
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
-    config = f"{workdir}/config.yaml"
+    config = (
+        f"{workdir}/config.yaml"
+        if os.path.exists(f"{workdir}/config.yaml")
+        else f"{workdir}/config.pkl"
+    )
     outdir = f"{workdir}/landscape.{E}"
 
     if args.outdir:
@@ -505,7 +511,7 @@ def main(args):
 
     logger.info("Analyzing volumes...")
     # get particle indices if the dataset was originally filtered
-    c = utils.load_config(config)
+    c = cryodrgn.config.load(config)
     particle_ind = (
         utils.load_pkl(c["dataset_args"]["ind"])
         if c["dataset_args"]["ind"] is not None

--- a/cryodrgn/commands/analyze_landscape_full.py
+++ b/cryodrgn/commands/analyze_landscape_full.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import os.path
 import pprint
 import shutil
 from datetime import datetime as dt
@@ -159,7 +160,7 @@ class MyDataset(Dataset):
 
 
 def generate_and_map_volumes(
-    zfile, cfg_pkl, weights, mask_mrc, pca_obj_pkl, landscape_dir, outdir, args
+    zfile, cfg, weights, mask_mrc, pca_obj_pkl, landscape_dir, outdir, args
 ):
     # Sample z
     logger.info(f"Sampling {args.N} particles from {zfile}")
@@ -175,7 +176,7 @@ def generate_and_map_volumes(
     assert torch.cuda.is_available(), "No GPUs detected"
     torch.set_default_tensor_type(torch.cuda.FloatTensor)  # type: ignore
 
-    cfg = config.update_config_v1(cfg_pkl)
+    cfg = config.update_config_v1(cfg)
     logger.info("Loaded configuration:")
     pprint.pprint(cfg)
 
@@ -288,7 +289,11 @@ def main(args):
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
-    cfg_pkl = f"{workdir}/config.yaml"
+    cfg = (
+        f"{workdir}/config.yaml"
+        if os.path.exists(f"{workdir}/config.yaml")
+        else f"{workdir}/config.pkl"
+    )
     landscape_dir = (
         f"{workdir}/landscape.{E}" if args.landscape_dir is None else args.landscape_dir
     )
@@ -320,7 +325,7 @@ def main(args):
         z = utils.load_pkl(z_sampled_pkl)
     else:
         z, embeddings = generate_and_map_volumes(
-            zfile, cfg_pkl, weights, mask_mrc, pca_obj_pkl, landscape_dir, outdir, args
+            zfile, cfg, weights, mask_mrc, pca_obj_pkl, landscape_dir, outdir, args
         )
         utils.save_pkl(embeddings, embeddings_pkl)
 

--- a/cryodrgn/commands/analyze_landscape_full.py
+++ b/cryodrgn/commands/analyze_landscape_full.py
@@ -288,7 +288,7 @@ def main(args):
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
-    cfg_pkl = f"{workdir}/config.pkl"
+    cfg_pkl = f"{workdir}/config.yaml"
     landscape_dir = (
         f"{workdir}/landscape.{E}" if args.landscape_dir is None else args.landscape_dir
     )

--- a/cryodrgn/commands/eval_images.py
+++ b/cryodrgn/commands/eval_images.py
@@ -110,7 +110,7 @@ def add_args(parser):
     )
 
     group = parser.add_argument_group(
-        "Overwrite architecture hyperparameters in config.pkl"
+        "Overwrite architecture hyperparameters in config.yaml"
     )
     group.add_argument("--zdim", type=int, help="Dimension of latent variable")
     group.add_argument(

--- a/cryodrgn/commands/eval_vol.py
+++ b/cryodrgn/commands/eval_vol.py
@@ -17,7 +17,11 @@ logger = logging.getLogger(__name__)
 def add_args(parser):
     parser.add_argument("weights", help="Model weights")
     parser.add_argument(
-        "-c", "--config", metavar="PKL", required=True, help="CryoDRGN config.pkl file"
+        "-c",
+        "--config",
+        metavar="YAML",
+        required=True,
+        help="CryoDRGN config.yaml file",
     )
     parser.add_argument(
         "-o", type=os.path.abspath, required=True, help="Output .mrc or directory"
@@ -72,7 +76,7 @@ def add_args(parser):
     )
 
     group = parser.add_argument_group(
-        "Overwrite architecture hyperparameters in config.pkl"
+        "Overwrite architecture hyperparameters in config.yaml"
     )
     group.add_argument("--norm", nargs=2, type=float)
     group.add_argument("-D", type=int, help="Box size")

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -24,6 +24,7 @@ from cryodrgn import ctf, dataset, models, mrc
 from cryodrgn.lattice import Lattice
 from cryodrgn.pose import PoseTracker
 from cryodrgn.models import DataParallelDecoder, Decoder
+import cryodrgn.config
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -10,9 +10,9 @@ import logging
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.nn.parallel import DataParallel
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
+import yaml
 
 try:
     import apex.amp as amp  # type: ignore
@@ -20,8 +20,7 @@ except ImportError:
     pass
 
 import cryodrgn
-import cryodrgn.types as types
-from cryodrgn import ctf, dataset, models, mrc, utils
+from cryodrgn import ctf, dataset, models, mrc
 from cryodrgn.lattice import Lattice
 from cryodrgn.pose import PoseTracker
 from cryodrgn.models import DataParallelDecoder, Decoder
@@ -328,10 +327,11 @@ def save_config(args, dataset, lattice, model, out_config):
         dataset_args=dataset_args, lattice_args=lattice_args, model_args=model_args
     )
     config["seed"] = args.seed
-    with open(out_config, "wb") as f:
-        pickle.dump(config, f)
-        meta = dict(time=dt.now(), cmd=sys.argv, version=cryodrgn.__version__)
-        pickle.dump(meta, f)
+    config["version"] = cryodrgn.__version__
+    config["time"] = dt.now()
+    config["cmd"] = sys.argv
+    with open(out_config, "w") as f:
+        yaml.dump(config, f)
 
 
 def get_latest(args):
@@ -469,7 +469,7 @@ def main(args):
     Apix = ctf_params[0, 0] if ctf_params is not None else 1
 
     # save configuration
-    out_config = f"{args.outdir}/config.pkl"
+    out_config = f"{args.outdir}/config.yaml"
     save_config(args, data, lattice, model, out_config)
 
     # Mixed precision training with AMP

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -327,11 +327,7 @@ def save_config(args, dataset, lattice, model, out_config):
         dataset_args=dataset_args, lattice_args=lattice_args, model_args=model_args
     )
     config["seed"] = args.seed
-    config["version"] = cryodrgn.__version__
-    config["time"] = dt.now()
-    config["cmd"] = sys.argv
-    with open(out_config, "w") as f:
-        yaml.dump(config, f)
+    cryodrgn.config.save(config, out_config)
 
 
 def get_latest(args):

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -12,7 +12,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-import yaml
 
 try:
     import apex.amp as amp  # type: ignore

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -13,7 +13,6 @@ import torch.nn as nn
 from torch.nn.parallel import DataParallel
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-import yaml
 
 try:
     import apex.amp as amp  # type: ignore  # PYR01
@@ -26,6 +25,7 @@ from cryodrgn.beta_schedule import get_beta_schedule
 from cryodrgn.lattice import Lattice
 from cryodrgn.models import HetOnlyVAE, unparallelize
 from cryodrgn.pose import PoseTracker
+import cryodrgn.config
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -533,11 +533,7 @@ def save_config(args, dataset, lattice, model, out_config):
         dataset_args=dataset_args, lattice_args=lattice_args, model_args=model_args
     )
     config["seed"] = args.seed
-    config["version"] = cryodrgn.__version__
-    config["time"] = dt.now()
-    config["cmd"] = sys.argv
-    with open(out_config, "w") as f:
-        yaml.dump(config, f)
+    cryodrgn.config.save(config, out_config)
 
 
 def get_latest(args):

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from torch.nn.parallel import DataParallel
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
+import yaml
 
 try:
     import apex.amp as amp  # type: ignore  # PYR01
@@ -532,10 +533,11 @@ def save_config(args, dataset, lattice, model, out_config):
         dataset_args=dataset_args, lattice_args=lattice_args, model_args=model_args
     )
     config["seed"] = args.seed
-    with open(out_config, "wb") as f:
-        pickle.dump(config, f)
-        meta = dict(time=dt.now(), cmd=sys.argv, version=cryodrgn.__version__)
-        pickle.dump(meta, f)
+    config["version"] = cryodrgn.__version__
+    config["time"] = dt.now()
+    config["cmd"] = sys.argv
+    with open(out_config, "w") as f:
+        yaml.dump(config, f)
 
 
 def get_latest(args):
@@ -741,7 +743,7 @@ def main(args):
     )
 
     # save configuration
-    out_config = "{}/config.pkl".format(args.outdir)
+    out_config = "{}/config.yaml".format(args.outdir)
     save_config(args, data, lattice, model, out_config)
 
     optim = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd)

--- a/cryodrgn/commands/view_config.py
+++ b/cryodrgn/commands/view_config.py
@@ -4,9 +4,11 @@ Display config information of a cryoDRGN job
 
 import argparse
 import os
-import pickle
+import os.path
 from pprint import pprint
 import logging
+import warnings
+from cryodrgn import utils
 
 logger = logging.getLogger(__name__)
 
@@ -19,16 +21,27 @@ def add_args(parser):
 
 
 def main(args):
-    f = open(f"{args.workdir}/config.pkl", "rb")
-    cfg = pickle.load(f)
-    try:
-        meta = pickle.load(f)
-        logger.info(f'Version: {meta["version"]}')
-        logger.info(f'Creation time: {meta["time"]}')
+    warnings.warn(
+        "The view_config command is deprecated."
+        "Please save configuration in yaml format and view the config.yaml file directly.",
+        DeprecationWarning,
+    )
+    config_yaml = f"{args.workdir}/config.yaml"
+    config_pkl = f"{args.workdir}/config.pkl"
+    if os.path.exists(config_yaml):
+        cfg = utils.load_yaml(config_yaml)
+    elif os.path.exists(config_pkl):
+        cfg = utils.load_pkl(config_pkl)
+    else:
+        raise RuntimeError(f"A configuration file was not found at {args.workdir}")
+
+    if "version" in cfg:
+        logger.info(f'Version: {cfg["version"]}')
+    if "time" in cfg:
+        logger.info(f'Creation time: {cfg["time"]}')
+    if "cmd" in cfg:
         logger.info("Command:")
-        print(" ".join(meta["cmd"]))
-    except:  # noqa: E722
-        pass
+        print(" ".join(cfg["cmd"]))
     logger.info("Config:")
     pprint(cfg)
 

--- a/cryodrgn/config.py
+++ b/cryodrgn/config.py
@@ -1,8 +1,8 @@
 from cryodrgn import utils
 
 
-def update_config_v1(config_pkl):
-    config = utils.load_pkl(config_pkl)
+def update_config_v1(config):
+    config = utils.load_config(config)
     arg = "feat_sigma"
     if arg not in config["model_args"]:
         assert config["model_args"]["pe_type"] != "gaussian"
@@ -13,8 +13,8 @@ def update_config_v1(config_pkl):
     return config
 
 
-def overwrite_config(config_pkl, args):
-    config = utils.load_pkl(config_pkl)
+def overwrite_config(config, args):
+    config = utils.load_config(config)
     if args.norm is not None:
         config["dataset_args"]["norm"] = args.norm
     v = vars(args)

--- a/cryodrgn/config.py
+++ b/cryodrgn/config.py
@@ -25,8 +25,6 @@ def load(config):
 
 
 def save(config: dict, filename: Optional[str] = None, folder: Optional[str] = None):
-    if not filename.endswith("config.yaml"):
-        raise AssertionError("noooooo")
     filename = filename or "config.yaml"
     if folder is not None:
         filename = os.path.join(folder, filename)
@@ -40,23 +38,6 @@ def save(config: dict, filename: Optional[str] = None, folder: Optional[str] = N
         config["cmd"] = sys.argv
 
     utils.save_yaml(config, filename)
-    return filename
-
-
-def save3(config: dict, filename: Optional[str] = None, folder: Optional[str] = None):
-    import pickle
-    from datetime import datetime as dt
-
-    if not filename.endswith("config.pkl"):
-        raise AssertionError("noooooo")
-    if folder is not None:
-        filename = os.path.join(folder, filename)
-
-    with open(filename, "wb") as f:
-        pickle.dump(config, f)
-        meta = dict(time=dt.now(), cmd=sys.argv, version=cryodrgn.__version__)
-        pickle.dump(meta, f)
-
     return filename
 
 

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -88,7 +88,7 @@ class LazyMRCData(data.Dataset):
         self.use_cupy = use_cupy  # estimate_normalization may need access to self.use_cupy, so save it first
         if norm is None:
             norm = self.estimate_normalization()
-        self.norm = norm
+        self.norm = [float(x) for x in norm]
         self.window = window_mask(ny, window_r, 0.99) if window else None
 
     def estimate_normalization(self, n=1000):
@@ -213,7 +213,7 @@ class MRCData(data.Dataset):
         self.particles = particles
         self.N = N
         self.D = particles.shape[1]  # ny + 1 after symmetrizing HT
-        self.norm = norm
+        self.norm = [float(x) for x in norm]
         self.keepreal = keepreal
         self.use_cupy = use_cupy
         if keepreal:
@@ -259,7 +259,7 @@ class PreprocessedMRCData(data.Dataset):
             self.particles = (self.particles - norm[0]) / norm[1]
 
         logger.info("Normalized HT by {} +/- {}".format(*norm))
-        self.norm = norm
+        self.norm = [float(x) for x in norm]
 
     def calc_statistic(self):
         pp = cp if (self.use_cupy and cp is not None) else np
@@ -375,7 +375,7 @@ class TiltMRCData(data.Dataset):
 
         self.particles = particles
         self.particles_tilt = particles_tilt
-        self.norm = norm
+        self.norm = [float(x) for x in norm]
         self.N = N
         self.D = particles.shape[1]
         self.keepreal = keepreal

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -1,6 +1,4 @@
 """Pytorch models"""
-import os.path
-import warnings
 from typing import Optional, Tuple, Type, Union, Sequence, Any
 import numpy as np
 import torch
@@ -10,6 +8,7 @@ import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 from torch.nn.parallel import DataParallel
 from cryodrgn import fft, lie_tools, utils
+import cryodrgn.config
 from cryodrgn.lattice import Lattice
 
 Norm = Sequence[Any]  # mean, std
@@ -90,7 +89,7 @@ class HetOnlyVAE(nn.Module):
         Returns:
             HetOnlyVAE instance, Lattice instance
         """
-        cfg = utils.load_config(config)
+        cfg = cryodrgn.config.load(config)
 
         c = cfg["lattice_args"]
         lat = Lattice(c["D"], extent=c["extent"], device=device)
@@ -176,7 +175,7 @@ def load_decoder(config, weights=None, device=None):
 
     Returns a decoder model
     """
-    cfg = utils.load_config(config)
+    cfg = cryodrgn.config.load(config)
     c = cfg["model_args"]
     D = cfg["lattice_args"]["D"]
     activation = {"relu": nn.ReLU, "leaky_relu": nn.LeakyReLU}[c["activation"]]

--- a/cryodrgn/models.py
+++ b/cryodrgn/models.py
@@ -1,5 +1,6 @@
 """Pytorch models"""
-
+import os.path
+import warnings
 from typing import Optional, Tuple, Type, Union, Sequence, Any
 import numpy as np
 import torch
@@ -8,7 +9,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 from torch.nn.parallel import DataParallel
-import cryodrgn.types as types
 from cryodrgn import fft, lie_tools, utils
 from cryodrgn.lattice import Lattice
 
@@ -80,17 +80,18 @@ class HetOnlyVAE(nn.Module):
 
     @classmethod
     def load(cls, config, weights=None, device=None):
-        """Instantiate a model from a config.pkl
+        """Instantiate a model from a config.yaml
 
         Inputs:
-            config (str, dict): Path to config.pkl or loaded config.pkl
+            config (str, dict): Path to config.yaml or loaded config.yaml
             weights (str): Path to weights.pkl
             device: torch.device object
 
         Returns:
             HetOnlyVAE instance, Lattice instance
         """
-        cfg = utils.load_pkl(config) if type(config) is str else config
+        cfg = utils.load_config(config)
+
         c = cfg["lattice_args"]
         lat = Lattice(c["D"], extent=c["extent"], device=device)
         c = cfg["model_args"]
@@ -166,16 +167,16 @@ class HetOnlyVAE(nn.Module):
 
 def load_decoder(config, weights=None, device=None):
     """
-    Instantiate a decoder model from a config.pkl
+    Instantiate a decoder model from a config.yaml
 
     Inputs:
-        config (str, dict): Path to config.pkl or loaded config.pkl
+        config (str, dict): Path to config.yaml or loaded config.yaml
         weights (str): Path to weights.pkl
         device: torch.device object
 
     Returns a decoder model
     """
-    cfg = utils.load_pkl(config) if type(config) is str else config
+    cfg = utils.load_config(config)
     c = cfg["model_args"]
     D = cfg["lattice_args"]["D"]
     activation = {"relu": nn.ReLU, "leaky_relu": nn.LeakyReLU}[c["activation"]]

--- a/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
@@ -195,7 +195,7 @@
    "outputs": [],
    "source": [
     "# Load configuration file\n",
-    "config = utils.load_pkl(f'{WORKDIR}/config.pkl')\n",
+    "config = utils.load_config(f'{WORKDIR}/config.yaml')\n",
     "print(config)"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
@@ -36,6 +36,7 @@
     "from cryodrgn import utils\n",
     "from cryodrgn import dataset\n",
     "from cryodrgn import ctf\n",
+    "import cryodrgn.config\n",
     "                \n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
@@ -195,7 +196,7 @@
    "outputs": [],
    "source": [
     "# Load configuration file\n",
-    "config = utils.load_config(f'{WORKDIR}/config.yaml')\n",
+    "config = cryodrgn.config.load(f'{WORKDIR}/config.yaml')\n",
     "print(config)"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_viz_template.ipynb
@@ -36,6 +36,7 @@
     "from cryodrgn import utils\n",
     "from cryodrgn import dataset\n",
     "from cryodrgn import ctf\n",
+    "import cryodrgn.config\n",
     "                \n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
@@ -143,7 +144,7 @@
    "outputs": [],
    "source": [
     "# Load configuration file\n",
-    "config = utils.load_config(f'{WORKDIR}/config.yaml')\n",
+    "config = cryodrgn.config.load(f'{WORKDIR}/config.yaml')\n",
     "print(config)"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_viz_template.ipynb
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "# Load configuration file\n",
-    "config = utils.load_pkl(f'{WORKDIR}/config.pkl')\n",
+    "config = utils.load_config(f'{WORKDIR}/config.yaml')\n",
     "print(config)"
    ]
   },
@@ -679,7 +679,7 @@
     "        os.mkdir(outdir)\n",
     "    np.savetxt(f'{outdir}/zfile.txt', zvalues)\n",
     "    analysis.gen_volumes(f'{WORKDIR}/weights.{EPOCH}.pkl',\n",
-    "                         f'{WORKDIR}/config.pkl',\n",
+    "                         f'{WORKDIR}/config.yaml',\n",
     "                         f'{outdir}/zfile.txt',\n",
     "                         f'{outdir}', **kwargs)\n",
     "    return FileLinks(f'{outdir}/')"

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -60,28 +60,11 @@ def load_yaml(yamlfile: str):
         return yaml.safe_load(f)
 
 
-def save_yaml(data, out_yamlfile: str, mode: str = "wb"):
-    if mode == "wb" and os.path.exists(out_yamlfile):
+def save_yaml(data, out_yamlfile: str, mode: str = "w"):
+    if mode == "w" and os.path.exists(out_yamlfile):
         logger.warning(f"Warning: {out_yamlfile} already exists. Overwriting.")
     with open(out_yamlfile, mode) as f:
         yaml.dump(data, f)
-
-
-def load_config(config):
-    if isinstance(config, str):
-        ext = os.path.splitext(config)[-1]
-        if ext == ".pkl":
-            warnings.warn(
-                "Loading configuration from a .pkl file is deprecated. Please save/load configuration"
-                "as a .yaml file instead."
-            )
-            return load_pkl(config)
-        elif ext in (".yml", ".yaml"):
-            return load_yaml(config)
-        else:
-            raise RuntimeError(f"Unrecognized config extension {ext}")
-    else:
-        return config
 
 
 def R_from_eman(a: np.ndarray, b: np.ndarray, y: np.ndarray) -> np.ndarray:

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -6,7 +6,6 @@ import yaml
 import logging
 from typing import Tuple
 import numpy as np
-import warnings
 
 logger = logging.getLogger(__name__)
 

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -2,9 +2,11 @@ from collections.abc import Hashable
 import functools
 import os
 import pickle
+import yaml
 import logging
 from typing import Tuple
 import numpy as np
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +53,35 @@ def save_pkl(data, out_pkl: str, mode: str = "wb") -> None:
         logger.warning(f"Warning: {out_pkl} already exists. Overwriting.")
     with open(out_pkl, mode) as f:
         pickle.dump(data, f)
+
+
+def load_yaml(yamlfile: str):
+    with open(yamlfile, "r") as f:
+        return yaml.safe_load(f)
+
+
+def save_yaml(data, out_yamlfile: str, mode: str = "wb"):
+    if mode == "wb" and os.path.exists(out_yamlfile):
+        logger.warning(f"Warning: {out_yamlfile} already exists. Overwriting.")
+    with open(out_yamlfile, mode) as f:
+        yaml.dump(data, f)
+
+
+def load_config(config):
+    if isinstance(config, str):
+        ext = os.path.splitext(config)[-1]
+        if ext == ".pkl":
+            warnings.warn(
+                "Loading configuration from a .pkl file is deprecated. Please save/load configuration"
+                "as a .yaml file instead."
+            )
+            return load_pkl(config)
+        elif ext in (".yml", ".yaml"):
+            return load_yaml(config)
+        else:
+            raise RuntimeError(f"Unrecognized config extension {ext}")
+    else:
+        return config
 
 
 def R_from_eman(a: np.ndarray, b: np.ndarray, y: np.ndarray) -> np.ndarray:

--- a/docs/pages/empiar_tutorial.md
+++ b/docs/pages/empiar_tutorial.md
@@ -596,7 +596,7 @@ In this tutorial we will walk through the commands and analysis for Step 1 and S
 
     The training will take ~7.5 min/epoch on a V100 GPU, requiring ~7 hours total. The output directory will contain the following files:
 
-    - `config.pkl` a configuration file containing all inputs and settings for the job
+    - `config.yaml` a configuration file containing all inputs and settings for the job
     - `weights.pkl` the final neural network weights (and intermediate checkpoints `weights.n.pkl`)
     - `z.pkl` the final per-particle latent embeddings (and embeddings from intermediate epochs `z.n.pkl`)
 
@@ -687,9 +687,9 @@ $ cryodrgn analyze tutorial/00_vae128 49 --flip --Apix 3.275
      0.06840914 0.05249962]
     2021-02-04 02:57:18     Generating volumes...
     2021-02-04 02:57:18     Running command:
-    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.pkl --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1 --Apix 1
+    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.yaml --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1 --Apix 1
     2021-02-04 02:57:20     Use cuda True
-    2021-02-04 02:57:20     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.pkl', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x7ffed8e3fe18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1/z_values.txt')
+    2021-02-04 02:57:20     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.yaml', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x7ffed8e3fe18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc1/z_values.txt')
     2021-02-04 02:57:20     Loaded configuration:
     {'dataset_args': {'ctf': '/nobackup/users/zhonge/cryodrgn/11_l17_ribo/data/ctf.new.pkl',
                       'datadir': None,
@@ -738,9 +738,9 @@ $ cryodrgn analyze tutorial/00_vae128 49 --flip --Apix 3.275
      -0.25299058 -1.62566469]
     2021-02-04 02:57:40     Finsihed in 0:00:19.785367
     2021-02-04 02:57:40     Running command:
-    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.pkl --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2 --Apix 1
+    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.yaml --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2 --Apix 1
     2021-02-04 02:57:42     Use cuda True
-    2021-02-04 02:57:42     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.pkl', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x7ffea04efe18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2/z_values.txt')
+    2021-02-04 02:57:42     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.yaml', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x7ffea04efe18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/pc2/z_values.txt')
     2021-02-04 02:57:42     Loaded configuration:
     {'dataset_args': {'ctf': '/nobackup/users/zhonge/cryodrgn/11_l17_ribo/data/ctf.new.pkl',
                       'datadir': None,
@@ -791,9 +791,9 @@ $ cryodrgn analyze tutorial/00_vae128 49 --flip --Apix 3.275
     2021-02-04 02:57:53     K-means clustering...
     2021-02-04 02:58:00     Generating volumes...
     2021-02-04 02:58:00     Running command:
-    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.pkl --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20 --Apix 1
+    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.yaml --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20 --Apix 1
     2021-02-04 02:58:02     Use cuda True
-    2021-02-04 02:58:02     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.pkl', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x7ffeb2fded90>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20/z_values.txt')
+    2021-02-04 02:58:02     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/config.yaml', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x7ffeb2fded90>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/tutorial/00/analyze.49/kmeans20/z_values.txt')
     2021-02-04 02:58:02     Loaded configuration:
     {'dataset_args': {'ctf': '/nobackup/users/zhonge/cryodrgn/11_l17_ribo/data/ctf.new.pkl',
                       'datadir': None,
@@ -1333,9 +1333,9 @@ We flip the handedness of the output volumes with the flag `--flip` and set the 
      0.09139399 0.08733987]
     2021-02-28 14:24:49     Generating volumes...
     2021-02-28 14:24:49     Running command:
-    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.pkl --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1 --Apix 1
+    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.yaml --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1 --Apix 1
     2021-02-28 14:24:50     Use cuda True
-    2021-02-28 14:24:50     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.pkl', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x2000ac580e18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1/z_values.txt')
+    2021-02-28 14:24:50     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.yaml', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x2000ac580e18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc1/z_values.txt')
     2021-02-28 14:24:50     Loaded configuration:
     {'dataset_args': {'ctf': '/nobackup/users/zhonge/cryodrgn/11_l17_ribo/data/ctf.new.pkl',
                       'datadir': None,
@@ -1384,9 +1384,9 @@ We flip the handedness of the output volumes with the flag `--flip` and set the 
       1.13353181  2.00136567]
     2021-02-28 14:26:24     Finsihed in 0:01:33.787293
     2021-02-28 14:26:25     Running command:
-    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.pkl --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2 --Apix 1
+    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.yaml --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2 --Apix 1
     2021-02-28 14:26:27     Use cuda True
-    2021-02-28 14:26:27     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.pkl', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x2000ac580e18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2/z_values.txt')
+    2021-02-28 14:26:27     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.yaml', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x2000ac580e18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/pc2/z_values.txt')
     2021-02-28 14:26:27     Loaded configuration:
     {'dataset_args': {'ctf': '/nobackup/users/zhonge/cryodrgn/11_l17_ribo/data/ctf.new.pkl',
                       'datadir': None,
@@ -1437,9 +1437,9 @@ We flip the handedness of the output volumes with the flag `--flip` and set the 
     2021-02-28 14:27:56     K-means clustering...
     2021-02-28 14:28:01     Generating volumes...
     2021-02-28 14:28:01     Running command:
-    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.pkl --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20 --Apix 1
+    cryodrgn eval_vol /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl --config /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.yaml --zfile /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20/z_values.txt -o /nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20 --Apix 1
     2021-02-28 14:28:03     Use cuda True
-    2021-02-28 14:28:03     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.pkl', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x2000ac580e18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20/z_values.txt')
+    2021-02-28 14:28:03     Namespace(Apix=1.0, D=None, activation='relu', config='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/config.yaml', domain=None, downsample=None, enc_mask=None, encode_mode=None, flip=False, func=<function main at 0x2000ac580e18>, l_extent=None, n=10, norm=None, o='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20', pdim=None, pe_dim=None, pe_type=None, players=None, prefix='vol_', qdim=None, qlayers=None, verbose=False, weights='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/weights.49.pkl', z=None, z_end=None, z_start=None, zdim=None, zfile='/nobackup/users/zhonge/cryodrgn/11_l17_ribo/04_vae256_gpu/3_gpu1_b8/analyze.49/kmeans20/z_values.txt')
     2021-02-28 14:28:03     Loaded configuration:
     {'dataset_args': {'ctf': '/nobackup/users/zhonge/cryodrgn/11_l17_ribo/data/ctf.new.pkl',
                       'datadir': None,
@@ -1865,7 +1865,7 @@ Note that you could specify arbitrary data points as the anchor points, e.g. you
 
 ```
 $ cd graph_traversal
-$ cryodrgn eval_vol ../../weights.49.pkl -c ../../config.pkl --zfile z.path.txt -o .
+$ cryodrgn eval_vol ../../weights.49.pkl -c ../../config.yaml --zfile z.path.txt -o .
 ```
 
 #### Generating assembly trajectories
@@ -1890,7 +1890,7 @@ This will produce a `path.txt` file and a `z.path.txt` file showing the indices 
 
 ```bash
 $ cd assembly_path_A
-$ cryodrgn eval_vol ../../weights.49.pkl -c ../../config.pkl --zfile z.path.txt -o .
+$ cryodrgn eval_vol ../../weights.49.pkl -c ../../config.yaml --zfile z.path.txt -o .
 ```
 
 <iframe src="https://widgets.figshare.com/articles/21170974/embed?show_title=1" width="568" height="351" allowfullscreen frameborder="0"></iframe>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pandas",
     "numpy",
     "matplotlib",
+    "pyyaml",
     "scipy>=1.3.1",
     "scikit-learn",
     "seaborn<0.12",

--- a/testing/unittest.sh
+++ b/testing/unittest.sh
@@ -2,22 +2,22 @@ set -e
 set -x
 
 # Test various file format loading options -- loss should be around 0.02
-cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon -n 10
-cryodrgn train_nn data/toy_projections.star --poses data/toy_angles.pkl -o output/toy_recon -n 10
-cryodrgn train_nn data/toy_projections.txt --poses data/toy_angles.pkl -o output/toy_recon -n 10
+cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon -n 10 --no-amp
+cryodrgn train_nn data/toy_projections.star --poses data/toy_angles.pkl -o output/toy_recon -n 10 --no-amp
+cryodrgn train_nn data/toy_projections.txt --poses data/toy_angles.pkl -o output/toy_recon -n 10 --no-amp
 
 # Test translations
 python ../utils/translate_stack.py data/toy_projections.mrcs data/toy_trans.pkl -o output/toy_projections.trans.mrcs --tscale -1
-cryodrgn train_nn output/toy_projections.trans.mrcs --poses data/toy_rot_trans.pkl -o output/toy_recon -n 10
-cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_rot_zerotrans.pkl -o output/toy_recon -n 10
+cryodrgn train_nn output/toy_projections.trans.mrcs --poses data/toy_rot_trans.pkl -o output/toy_recon -n 10 --no-amp
+cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_rot_zerotrans.pkl -o output/toy_recon -n 10 --no-amp
 
 # Do pose SGD
 cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_rot_zerotrans.pkl -o output/toy_recon --do-pose-sgd --domain hartley
 
 # Other decoder architectures
-cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon --domain hartley -n 2
-#cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon --pe-type none -n 2
-cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon --pe-type none --domain hartley -n 2
+cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon --domain hartley -n 2 --no-amp
+#cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon --pe-type none -n 2 --no-amp --no-amp
+cryodrgn train_nn data/toy_projections.mrcs --poses data/toy_angles.pkl -o output/toy_recon --pe-type none --domain hartley -n 2 --no-amp
 
 # Voxel-based backprojection
 cryodrgn backproject_voxel data/hand.mrcs --poses data/hand_rot.pkl -o output/backproject.mrc
@@ -30,14 +30,14 @@ cryodrgn train_vae data/hand.mrcs -o output/hand_recon_vae --lr .0001 --seed 0 -
 
 # Test evaluation script
 cryodrgn analyze output/toy_recon_vae 9
-cryodrgn eval_vol output/toy_recon_vae/weights.pkl -c output/toy_recon_vae/config.pkl -z 0 0 0 0 0 0 0 0 0 0 -o output/toy_recon_vae/vol.mrc
-cryodrgn eval_images data/toy_projections.mrcs output/toy_recon_vae/weights.pkl -c output/toy_recon_vae/config.pkl -o output/toy_recon_vae/losses.pkl --out-z output/toy_recon_vae/z_eval.pkl --poses data/toy_angles.pkl
+cryodrgn eval_vol output/toy_recon_vae/weights.pkl -c output/toy_recon_vae/config.yaml -z 0 0 0 0 0 0 0 0 0 0 -o output/toy_recon_vae/vol.mrc
+cryodrgn eval_images data/toy_projections.mrcs output/toy_recon_vae/weights.pkl -c output/toy_recon_vae/config.yaml -o output/toy_recon_vae/losses.pkl --out-z output/toy_recon_vae/z_eval.pkl --poses data/toy_angles.pkl
 cryodrgn pc_traversal output/toy_recon_vae/z.pkl -o output/toy_recon_vae/pc_traversal
 cryodrgn graph_traversal output/toy_recon_vae/z.pkl --anchors 0 10 100 -o output/toy_recon_vae/graph_traversal/path.txt --out-z output/toy_recon_vae/graph_traversal/z.path.txt
 
 # Test apex.amp
-cryodrgn train_nn data/hand.mrcs --poses data/hand_rot.pkl -o output/hand_recon -b 8
-cryodrgn train_nn data/hand.mrcs --poses data/hand_rot.pkl -o output/hand_recon --amp -b 8
+cryodrgn train_nn data/hand.mrcs --poses data/hand_rot.pkl -o output/hand_recon -b 8 --no-amp
+cryodrgn train_nn data/hand.mrcs --poses data/hand_rot.pkl -o output/hand_recon --amp -b 8 --no-amp
 
 # CTF testing
 cryodrgn parse_ctf_csparc data/cryosparc_P12_J24_001_particles.cs -o test_ctf.pkl

--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -135,7 +135,7 @@ def test_run(mrcs_file, poses_file):
         [
             "output/weights.3.pkl",
             "--config",
-            "output/config.pkl",
+            "output/config.yaml",
             "--zfile",
             "output/graph_traversal_zpath.txt",
             "-o",

--- a/utils/analyze_convergence.py
+++ b/utils/analyze_convergence.py
@@ -748,7 +748,7 @@ def generate_volumes(workdir, outdir, epochs, Apix, flip, invert, downsample, de
     """
     for epoch in epochs:
         weights = f"{workdir}/weights.{epoch}.pkl"
-        config = f"{workdir}/config.pkl"
+        config = f"{workdir}/config.yaml"
         zfile = f"{outdir}/repr_particles/latent_representative.{epoch}.txt"
         volsdir = f"{outdir}/vols.{epoch}"
 
@@ -1044,7 +1044,7 @@ def main(args):
     if epochs[-1] != E:
         epochs = np.append(epochs, E)
     workdir = args.workdir
-    config = f"{workdir}/config.pkl"
+    config = f"{workdir}/config.yaml"
     logfile = f"{workdir}/run.log"
 
     # assert all required files are locatable
@@ -1089,7 +1089,7 @@ def main(args):
 
     # Get total number of particles, latent space dimensionality, input image size
     n_particles_total, n_dim = utils.load_pkl(f"{workdir}/z.{E}.pkl").shape
-    cfg = utils.load_pkl(config)
+    cfg = utils.load_config(config)
     img_size = cfg["lattice_args"]["D"] - 1
 
     # Commonly used variables


### PR DESCRIPTION
Addresses issue #235.

Whenever configuration files are saved, `config.yaml` is used by default. When analysis commands are used, where a `config.pkl` would have been unconditionally read initially, we check to see if a `config.yaml` is present, failing which we look for a `config.pkl` (and generate a `DeprecationWarning` if we do so).

`view_config` works but generates a `DeprecationWarning` too.

I've tested the whole thing on old/newly generated training data, and it works correctly. I've modified the notebook templates too, but I haven't confirmed correct behavior on them. I'll leave a note here once I have. In the meantime, I'm opening up the PR so you can start looking around.