### PR TITLE
Fix machine stamp default in mrc.py for issue 248

### DIFF
--- a/cryodrgn/mrc.py
+++ b/cryodrgn/mrc.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import struct
 from collections import OrderedDict
@@ -154,7 +155,9 @@ class MRCHeader:
             yorg,
             zorg,
             b"MAP " if is_vol else b"\x00" * 4,
-            b"\x00" * 4,  # cmap, stamp
+            b"\x44\x44\x00\x00"
+            if sys.byteorder == "little"
+            else b"\x11\x11\x00\x00",  # machine stamp
             rms,  # rms
             0,  # nlabl
             b"\x00" * 800,  # labels

--- a/cryodrgn/mrc.py
+++ b/cryodrgn/mrc.py
@@ -63,7 +63,8 @@ class MRCHeader:
         "amean",  # float
         "ispg",
         "next",
-        "creatid",  # int, int, short, [pad 30]
+        "creatid",  # int, int, short, [pad 10]
+        "nversion",  # int, [pad 20]
         "nint",
         "nreal",  # short, [pad 20]
         "imodStamp",
@@ -89,7 +90,7 @@ class MRCHeader:
         "nlabl",
         "labels",
     ]  # int, char[10][80]
-    FSTR = "3ii3i3i3f3f3i3f2ih30x2h20x2i6h6f3f4s4sfi800s"
+    FSTR = "3ii3i3i3f3f3i3f2ih10xi16x2h20x2i6h6f3f4s4sfi800s"
 
     def __init__(self, header_values, extended_header=b"", endianness="="):
         self.fields = OrderedDict(zip(self.FIELDS, header_values))
@@ -168,6 +169,7 @@ class MRCHeader:
             ispg,
             0,  # exthd_size
             0,  # creatid
+            20140,  # nversion
             0,
             0,  # nint, nreal
             0,

--- a/cryodrgn/starfile.py
+++ b/cryodrgn/starfile.py
@@ -149,7 +149,7 @@ class Starfile:
         header = mrc.parse_header(mrcs[0])
         D = header.D  # image size along one dimension in pixels
         dtype = header.dtype
-        stride = dtype().itemsize * D * D
+        stride = dtype.itemsize * D * D
         dataset = [
             LazyImage(f, (D, D), dtype, 1024 + ii * stride) for ii, f in zip(ind, mrcs)
         ]


### PR DESCRIPTION
Addresses issue #248.

It also seems like in addition to the incorrect MACHST field, we're also writing an incorrect MAP field - the [specification](https://www.ccpem.ac.uk/mrc_format/mrc2014.php) indices that it should always be `MAP `, no exceptions, and certainly `mrcfile` insists it be so as well. I don't know why we choose `MAP ` only if its a volume. Unless I'm missing something, that requirement holds for both 3D volumes as well as 2D images.

There's also the question of what `cryoDRGN` should do if it ever encounters an mrc file where the byte-order is not the same as the host machine. It currently ignores it completely, but this is something that `mrcfile` takes care of correctly.

This PR is meant to address these issues. I'll keep this in draft mode till I validate it against `mrcfile` a little bit more..