### PR TITLE
Vb/pytest fix

### DIFF
--- a/cryodrgn/mrc.py
+++ b/cryodrgn/mrc.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import struct
 from collections import OrderedDict
@@ -154,7 +155,9 @@ class MRCHeader:
             yorg,
             zorg,
             b"MAP " if is_vol else b"\x00" * 4,
-            b"\x00" * 4,  # cmap, stamp
+            b"\x44\x44\x00\x00"
+            if sys.byteorder == "little"
+            else b"\x11\x11\x00\x00",  # machine stamp
             rms,  # rms
             0,  # nlabl
             b"\x00" * 800,  # labels

--- a/cryodrgn/starfile.py
+++ b/cryodrgn/starfile.py
@@ -149,7 +149,7 @@ class Starfile:
         header = mrc.parse_header(mrcs[0])
         D = header.D  # image size along one dimension in pixels
         dtype = header.dtype
-        stride = dtype().itemsize * D * D
+        stride = dtype.itemsize * D * D
         dataset = [
             LazyImage(f, (D, D), dtype, 1024 + ii * stride) for ii, f in zip(ind, mrcs)
         ]

--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -102,7 +102,7 @@ def test_run(mrcs_file, poses_file):
             "1",
         ]
     )
-    shutil.rmtree("output/landscape.3", ignore_errors=True)
+    shutil.rmtree("output/landscape.2", ignore_errors=True)
     analyze_landscape.main(args)
 
     args = graph_traversal.add_args(argparse.ArgumentParser()).parse_args(


### PR DESCRIPTION
Removing the correct temporarily created folder during pytest, so one can run the tests again and again without errors. This would not have shown up in the CI since it runs on a fresh machine everytime.