### PR TITLE
Removing correct temp folder in pytest

### DIFF
--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -102,7 +102,7 @@ def test_run(mrcs_file, poses_file):
             "1",
         ]
     )
-    shutil.rmtree("output/landscape.3", ignore_errors=True)
+    shutil.rmtree("output/landscape.2", ignore_errors=True)
     analyze_landscape.main(args)
 
     args = graph_traversal.add_args(argparse.ArgumentParser()).parse_args(


### PR DESCRIPTION
I realized currently one cannot rerun `pytest` locally again and again without errors. I'm removing the correct temporarily created output folder here so it can be re-run. This must have gotten out of sync when I reduced the no. of epochs in the `test_quick` test for faster testing.

This would not have shown up in the CI since it uses a fresh machine each time anyway.