### PR TITLE
Fixes for issue 258

### DIFF
--- a/cryodrgn/commands/abinit_het.py
+++ b/cryodrgn/commands/abinit_het.py
@@ -27,7 +27,9 @@ logger = logging.getLogger(__name__)
 
 def add_args(parser):
     parser.add_argument(
-        "particles", type=os.path.abspath, help="Input particles (.mrcs, .txt or .star)"
+        "particles",
+        type=os.path.abspath,
+        help="Input particles (.mrcs, .star, .cs, or .txt)",
     )
     parser.add_argument(
         "-o",
@@ -101,7 +103,7 @@ def add_args(parser):
     group.add_argument(
         "--lazy",
         action="store_true",
-        help="Memory efficient training by loading data in chunks",
+        help="Lazy loading if full dataset is too large to fit in memory",
     )
     group.add_argument(
         "--preprocessed",
@@ -164,12 +166,12 @@ def add_args(parser):
     group.add_argument(
         "--beta-control",
         type=float,
-        help="KL-Controlled VAE gamma. Beta is KL target. (default: %(default)s)",
+        help="KL-Controlled VAE gamma. Beta is KL target",
     )
     group.add_argument(
         "--equivariance",
         type=float,
-        help="Strength of equivariance loss (default: %(default)s)",
+        help="Strength of equivariance loss",
     )
     group.add_argument(
         "--eq-start-it",
@@ -191,13 +193,16 @@ def add_args(parser):
         help="Data normalization as shift, 1/scale (default: mean, std of dataset)",
     )
     group.add_argument(
-        "--l-ramp-epochs", type=int, default=0, help="default: %(default)s"
+        "--l-ramp-epochs",
+        type=int,
+        default=0,
+        help="Number of epochs to ramp up to --l-end (default: %(default)s)",
     )
     group.add_argument(
         "--l-ramp-model",
         type=int,
         default=0,
-        help="If 1, then during ramp only train the model up to l-max",
+        help="If 1, then during ramp only train the model up to l-max (default: %(default)s)",
     )
     group.add_argument(
         "--reset-model-every", type=int, help="If set, reset the model every N epochs"
@@ -229,7 +234,10 @@ def add_args(parser):
         "--l-end", type=int, default=32, help="End L radius (default: %(default)s)"
     )
     group.add_argument(
-        "--niter", type=int, default=4, help="Number of iterations of grid subdivision"
+        "--niter",
+        type=int,
+        default=4,
+        help="Number of iterations of grid subdivision (default: %(default)s)",
     )
     group.add_argument(
         "--t-extent",
@@ -238,10 +246,23 @@ def add_args(parser):
         help="+/- pixels to search over translations (default: %(default)s)",
     )
     group.add_argument(
-        "--t-ngrid", type=float, default=7, help="Initial grid size for translations"
+        "--t-ngrid",
+        type=float,
+        default=7,
+        help="Initial grid size for translations (default: %(default)s)",
     )
-    group.add_argument("--t-xshift", type=float, default=0)
-    group.add_argument("--t-yshift", type=float, default=0)
+    group.add_argument(
+        "--t-xshift",
+        type=float,
+        default=0,
+        help="X-axis translation shift (default: %(default)s)",
+    )
+    group.add_argument(
+        "--t-yshift",
+        type=float,
+        default=0,
+        help="Y-axis translation shift (default: %(default)s)",
+    )
     group.add_argument(
         "--pretrain",
         type=int,
@@ -258,18 +279,18 @@ def add_args(parser):
         "--nkeptposes",
         type=int,
         default=8,
-        help="Number of poses to keep at each refinement interation during branch and bound",
+        help="Number of poses to keep at each refinement interation during branch and bound (default: %(default)s)",
     )
     group.add_argument(
         "--base-healpy",
         type=int,
         default=2,
-        help="Base healpy grid for pose search. Higher means exponentially higher resolution.",
+        help="Base healpy grid for pose search. Higher means exponentially higher resolution (default: %(default)s)",
     )
     group.add_argument(
         "--pose-model-update-freq",
         type=int,
-        help="If set, only update the model used for pose search every N examples.",
+        help="If set, only update the model used for pose search every N examples",
     )
 
     group = parser.add_argument_group("Encoder Network")
@@ -348,7 +369,7 @@ def add_args(parser):
         "--domain",
         choices=("hartley", "fourier"),
         default="hartley",
-        help="Decoder representation domain (default: %(default)s)",
+        help="Volume decoder representation (default: %(default)s)",
     )
     group.add_argument(
         "--activation",

--- a/cryodrgn/commands/abinit_homo.py
+++ b/cryodrgn/commands/abinit_homo.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 
 def add_args(parser):
     parser.add_argument(
-        "particles", type=os.path.abspath, help="Particle stack file (.mrcs)"
+        "particles",
+        type=os.path.abspath,
+        help="Input particles (.mrcs, .star, .cs, or .txt)",
     )
     parser.add_argument(
         "-o",
@@ -61,7 +63,7 @@ def add_args(parser):
         help="Logging interval in N_IMGS (default: %(default)s)",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increaes verbosity"
+        "-v", "--verbose", action="store_true", help="Increase verbosity"
     )
     parser.add_argument(
         "--seed", type=int, default=np.random.randint(0, 100000), help="Random seed"
@@ -73,7 +75,10 @@ def add_args(parser):
         help="Do not invert data sign",
     )
     parser.add_argument(
-        "--window", action="store_true", help="Real space windowing of dataset"
+        "--no-window",
+        dest="window",
+        action="store_false",
+        help="Turn off real space windowing of dataset",
     )
     parser.add_argument(
         "--window-r",
@@ -81,7 +86,9 @@ def add_args(parser):
         default=0.85,
         help="Windowing radius (default: %(default)s)",
     )
-    parser.add_argument("--ind", type=os.path.abspath, help="Filter indices")
+    parser.add_argument(
+        "--ind", type=os.path.abspath, help="Filter particle stack by these indices"
+    )
 
     group = parser.add_argument_group("Tilt series")
     group.add_argument("--tilt", help="Particle stack file (.mrcs)")
@@ -97,13 +104,26 @@ def add_args(parser):
         "--t-extent",
         type=float,
         default=10,
-        help="+/- pixels to search over translations",
+        help="+/- pixels to search over translations (default: %(default)s)",
     )
     group.add_argument(
-        "--t-ngrid", type=float, default=7, help="Initial grid size for translations"
+        "--t-ngrid",
+        type=float,
+        default=7,
+        help="Initial grid size for translations (default: %(default)s)",
     )
-    group.add_argument("--t-xshift", type=float, default=0)
-    group.add_argument("--t-yshift", type=float, default=0)
+    group.add_argument(
+        "--t-xshift",
+        type=float,
+        default=0,
+        help="X-axis translation shift (default: %(default)s)",
+    )
+    group.add_argument(
+        "--t-yshift",
+        type=float,
+        default=0,
+        help="Y-axis translation shift (default: %(default)s)",
+    )
     group.add_argument(
         "--no-trans", action="store_true", help="Don't search over translations"
     )
@@ -170,7 +190,10 @@ def add_args(parser):
         "--l-end", type=int, default=32, help="End L radius (default: %(default)s)"
     )
     group.add_argument(
-        "--niter", type=int, default=4, help="Number of iterations of grid subdivision"
+        "--niter",
+        type=int,
+        default=4,
+        help="Number of iterations of grid subdivision (default: %(default)s)",
     )
     group.add_argument(
         "--l-ramp-epochs",
@@ -185,18 +208,18 @@ def add_args(parser):
         "--nkeptposes",
         type=int,
         default=8,
-        help="Number of poses to keep at each refinement interation during branch and bound",
+        help="Number of poses to keep at each refinement interation during branch and bound (default: %(default)s)",
     )
     group.add_argument(
         "--base-healpy",
         type=int,
         default=2,
-        help="Base healpy grid for pose search. Higher means exponentially higher resolution.",
+        help="Base healpy grid for pose search. Higher means exponentially higher resolution (default: %(default)s)",
     )
     group.add_argument(
         "--pose-model-update-freq",
         type=int,
-        help="If set, only update the model used for pose search every N examples.",
+        help="If set, only update the model used for pose search every N examples",
     )
 
     group = parser.add_argument_group("Network Architecture")
@@ -253,7 +276,7 @@ def add_args(parser):
         "--feat-sigma",
         type=float,
         default=0.5,
-        help="Scale for random Gaussian features",
+        help="Scale for random Gaussian features (default: %(default)s)",
     )
 
     return parser

--- a/cryodrgn/commands/train_nn.py
+++ b/cryodrgn/commands/train_nn.py
@@ -62,7 +62,7 @@ def add_args(parser):
         help="Logging interval in N_IMGS (default: %(default)s)",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increaes verbosity"
+        "-v", "--verbose", action="store_true", help="Increase verbosity"
     )
     parser.add_argument(
         "--seed", type=int, default=np.random.randint(0, 100000), help="Random seed"
@@ -148,7 +148,9 @@ def add_args(parser):
     )
 
     group = parser.add_argument_group("Pose SGD")
-    group.add_argument("--do-pose-sgd", action="store_true", help="Refine poses")
+    group.add_argument(
+        "--do-pose-sgd", action="store_true", help="Refine poses with gradient descent"
+    )
     group.add_argument(
         "--pretrain",
         type=int,
@@ -165,7 +167,7 @@ def add_args(parser):
         "--pose-lr",
         type=float,
         default=1e-4,
-        help="Learning rate in Adam optimizer (default: %(default)s)",
+        help="Learning rate for pose optimizer (default: %(default)s)",
     )
 
     group = parser.add_argument_group("Network Architecture")
@@ -222,7 +224,7 @@ def add_args(parser):
         "--feat-sigma",
         type=float,
         default=0.5,
-        help="Scale for random Gaussian features",
+        help="Scale for random Gaussian features (default: %(default)s)",
     )
 
     return parser

--- a/cryodrgn/commands/train_vae.py
+++ b/cryodrgn/commands/train_vae.py
@@ -67,7 +67,7 @@ def add_args(parser):
         help="Logging interval in N_IMGS (default: %(default)s)",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increaes verbosity"
+        "-v", "--verbose", action="store_true", help="Increase verbosity"
     )
     parser.add_argument(
         "--seed", type=int, default=np.random.randint(0, 100000), help="Random seed"
@@ -106,7 +106,7 @@ def add_args(parser):
     group.add_argument(
         "--lazy",
         action="store_true",
-        help="Lazy loading if full dataset is too large to fit in memory (Should copy dataset to SSD)",
+        help="Lazy loading if full dataset is too large to fit in memory",
     )
     group.add_argument(
         "--preprocessed",
@@ -127,7 +127,7 @@ def add_args(parser):
     )
 
     group = parser.add_argument_group("Tilt series")
-    group.add_argument("--tilt", help="Particles (.mrcs)")
+    group.add_argument("--tilt", help="Particle stack file (.mrcs)")
     group.add_argument(
         "--tilt-deg",
         type=float,
@@ -170,14 +170,14 @@ def add_args(parser):
     group.add_argument(
         "--beta-control",
         type=float,
-        help="KL-Controlled VAE gamma. Beta is KL target. (default: %(default)s)",
+        help="KL-Controlled VAE gamma. Beta is KL target",
     )
     group.add_argument(
         "--norm",
         type=float,
         nargs=2,
         default=None,
-        help="Data normalization as shift, 1/scale (default: 0, std of dataset)",
+        help="Data normalization as shift, 1/scale (default: mean, std of dataset)",
     )
     group.add_argument(
         "--no-amp",
@@ -279,7 +279,7 @@ def add_args(parser):
         "--feat-sigma",
         type=float,
         default=0.5,
-        help="Scale for random Gaussian features",
+        help="Scale for random Gaussian features (default: %(default)s)",
     )
     group.add_argument(
         "--pe-dim",
@@ -290,7 +290,7 @@ def add_args(parser):
         "--domain",
         choices=("hartley", "fourier"),
         default="fourier",
-        help="Decoder representation domain (default: %(default)s)",
+        help="Volume decoder representation (default: %(default)s)",
     )
     group.add_argument(
         "--activation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "torch>=1.0.0",
-    "pandas",
+    "pandas<2",
     "numpy",
     "matplotlib",
     "scipy>=1.3.1",

--- a/tests/test_abinit.py
+++ b/tests/test_abinit.py
@@ -28,6 +28,7 @@ def test_abinit_het_and_backproject():
         "8",
         "--pe-dim",
         "8",
+        "--no-window",
     ]
 
     args = abinit_het.add_args(argparse.ArgumentParser()).parse_args(

--- a/tests/test_quick.py
+++ b/tests/test_quick.py
@@ -102,7 +102,7 @@ def test_run(mrcs_file, poses_file):
             "1",
         ]
     )
-    shutil.rmtree("output/landscape.3", ignore_errors=True)
+    shutil.rmtree("output/landscape.2", ignore_errors=True)
     analyze_landscape.main(args)
 
     args = graph_traversal.add_args(argparse.ArgumentParser()).parse_args(


### PR DESCRIPTION
Fixes for issue 258. I haven't changed default values anywhere, except that I added `--no-window` (assumed off) for `abinit_homo` and took off `--window` (originally assumed off).

I wrote a little script to confirm that all common arguments for `abinit_homo`, `train_nn`, `abinit_het`, `train_vae`, have common help strings where applicable, and here are the places where their help descriptions still differ. Some/all of these behaviors might be different on purpose, but putting them all in here for review.

```
--pretrain
  abinit_homo --> Number of initial iterations with random poses (default: 10000)
  train_nn --> Number of epochs with fixed poses before pose SGD (default: 5)
  abinit_het --> Number of initial iterations with random poses (default: 10000)
  train_vae --> Number of epochs with fixed poses before pose SGD (default: 1)
  
--pe-dim
  abinit_homo --> Num sinusoid features in positional encoding (default: D/2)
  train_nn --> Num sinusoid features in positional encoding (default: D/2)
  abinit_het --> Num features in positional encoding (default: image D)
  train_vae --> Num features in positional encoding (default: image D)
  
--beta
  abinit_het --> Choice of beta schedule or a constant for KLD weight (default: 1)
  train_vae --> Choice of beta schedule or a constant for KLD weight (default: 1/zdim)
```