### PR TITLE
pinning pandas<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "torch>=1.0.0",
-    "pandas",
+    "pandas<2",
     "numpy",
     "matplotlib",
     "scipy>=1.3.1",


### PR DESCRIPTION
We're seeing CI errors on the latest pandas version. I'll open an issue on this, but for now pinning `pandas` to `<2`.