### PR TITLE
Filter preprocessed dataset before loading

### DIFF
--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -243,10 +243,10 @@ class PreprocessedMRCData(data.Dataset):
         self.use_cupy = use_cupy
         if ind is not None:
             # First lazy load to avoid loading the whole dataset
-            particles = load_particles(mrcfile, True, datadir=datadir)
+            particles = load_particles(mrcfile, True)
             if not lazy:
                 # Then, load the desired particles specified by ind
-                particles = pp.array([particles[i].get() for i in ind])
+                particles = np.array([particles[i].get() for i in ind])
             else:
                 particles = particles[ind]
         else:

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -241,11 +241,17 @@ class PreprocessedMRCData(data.Dataset):
 
     def __init__(self, mrcfile, norm=None, ind=None, lazy=False, use_cupy=False):
         self.use_cupy = use_cupy
-        particles = load_particles(mrcfile, lazy=lazy)
-        self.lazy = lazy
         if ind is not None:
-            particles = particles[ind]
-
+            # First lazy load to avoid loading the whole dataset
+            particles = load_particles(mrcfile, True, datadir=datadir)
+            if not lazy:
+                # Then, load the desired particles specified by ind
+                particles = pp.array([particles[i].get() for i in ind])
+            else:
+                particles = particles[ind]
+        else:
+            particles = load_particles(mrcfile, lazy=lazy)
+        self.lazy = lazy
         self.particles = particles
         self.N = len(particles)
         if self.lazy:


### PR DESCRIPTION
Fix `PreprocessedMRCData` so that if a particle selection is provided, load only the selected particles, not the whole dataset. (This fix is already in `MRCData`.)