### PR TITLE
Bring back cryodrgn_utils filter_star

### DIFF
--- a/cryodrgn/commands_utils/filter_star.py
+++ b/cryodrgn/commands_utils/filter_star.py
@@ -4,7 +4,6 @@ Filter a .star file
 
 import argparse
 import os
-import warnings
 import logging
 from cryodrgn import starfile
 from cryodrgn import utils

--- a/cryodrgn/commands_utils/filter_star.py
+++ b/cryodrgn/commands_utils/filter_star.py
@@ -6,7 +6,8 @@ import argparse
 import os
 import warnings
 import logging
-from cryodrgn.commands_utils import write_star
+from cryodrgn import starfile
+from cryodrgn import utils
 
 logger = logging.getLogger(__name__)
 
@@ -19,20 +20,11 @@ def add_args(parser):
 
 
 def main(args):
-    warning_msg = "cryodrgn_utils filter_star is deprecated. Please use cryodrgn_utils write_star instead."
-    warnings.warn(warning_msg, DeprecationWarning)
-    logger.warning(f"WARNING: {warning_msg}")
-
-    args = write_star.add_args(argparse.ArgumentParser()).parse_args(
-        [
-            args.input,
-            "-o",
-            args.o,
-            "--ind",
-            args.ind,
-        ]
-    )
-    write_star.main(args)
+    s = starfile.Starfile.load(args.input)
+    ind = utils.load_pkl(args.ind)
+    df = s.df.loc[ind]
+    s = starfile.Starfile(headers=None, df=df)
+    s.write(args.o)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restore the script `cryodrgn_utils filter_star` to filter the rows of a star file. 

We recently changed filter_star to re-route the user to `cryodrgn_utils write_star` (which writes a new star file given a particle stack, CTF values and poses), but often we just want to filter a parent star file with all the micrograph details etc.