### PR TITLE
A couple of tests for require_contiguous

### DIFF
--- a/cryodrgn/source.py
+++ b/cryodrgn/source.py
@@ -160,7 +160,7 @@ class ImageSource:
     ) -> torch.Tensor:
         indices = self._convert_to_ndarray(indices)
         if self.data:  # cached data
-            images = self.data._images(indices)
+            images = self.data._images(indices, require_contiguous=require_contiguous)
         else:
             # Convert incoming caller indices to indices that this ImageSource will use
             if self.indices is not None:
@@ -214,6 +214,11 @@ class ArraySource(ImageSource):
         super().__init__(D=ny, n=nz)
 
     def _images(self, indices: np.ndarray, require_contiguous: bool = False):
+        """
+        Return ndarray data at specified indices.
+        Note that this implementation chooses to ignore `require_contiguous`
+        since fancy indexing on a realized ndarray is "fast enough" for all practical purposes.
+        """
         return self.array[indices, ...]
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -77,22 +77,21 @@ def test_loading_fast():
 
 def test_data_shuffler():
     dataset = ImageDataset(mrcfile=f"{DATA_FOLDER}/hand.mrcs")
-    # We could use the following, but this will result in 7 independent calls to
-    # the underlying ImageDataset's __getitem__ - not efficient
+    true_images_sum = dataset[np.arange(dataset.N)][0].cpu().numpy().sum(axis=0)
     data_loader = DataShuffler(dataset, batch_size=5, buffer_size=20)
 
     epoch1_indices, epoch2_indices = [], []
+    images_sum = np.zeros_like(true_images_sum)
 
     for i, minibatch in enumerate(data_loader):
         assert len(minibatch) == 3  # minibatch is a list of (particles, tilt, indices)
 
-        # We have 100 particles. For all but the last iteration *
-        # for all but the last iteration (100//7 = 14), we'll have 7 images each
         assert minibatch[0].shape == (5, 65, 65)
         assert minibatch[1].shape == (5, 65, 65)
         assert minibatch[2].shape == (5,)
 
         epoch1_indices.append(minibatch[2])
+        images_sum += minibatch[0].sum(axis=0).cpu().numpy()  # type: ignore
 
     for i, minibatch in enumerate(data_loader):
         epoch2_indices.append(minibatch[2])
@@ -107,3 +106,6 @@ def test_data_shuffler():
 
     # epochs should be shuffled differently
     assert any(epoch1_indices != epoch2_indices), epoch1_indices  # Should be reshuffled
+
+    # The summation of all images, however they're shuffled, should match true_images_sum
+    assert np.allclose(images_sum, true_images_sum, atol=1e-5)


### PR DESCRIPTION
Added a couple of tests for `require_contiguous`. Added a summation check for images obtained from `DataShuffler` (not just indices that it says its returning).

Getting images with `lazy=False` and `require_contiguous=True` currently always works, even when the indices to be retrieved are shuffled. It didn't have to be so, but its a reasonable implementation. I've just added an explicit comment here to indicate that this is the case.

Technically we can now take off the:
```
Sorry dude, --ind is not supported for the data shuffler.
```
etc., but its worth keeping to stick with the **explicit** ethos. (very unlikely that `--ind` and retrieval indices act in concert to cancel each other out).